### PR TITLE
Add settings cog with About panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ When a task is done, you mark it complete with the ✓ button. It disappears fro
 
 The **History panel** (opened from the header) shows a bar chart of how many tasks you completed each week for the past four weeks, and calls out your most productive week ever.
 
+The **settings cog** (top-right corner) opens a side panel. The **About** entry gives a plain-language overview of what the app is and how it works.
+
 ### Task details
 
 Each task supports:
@@ -102,10 +104,11 @@ Unit tests use **Vitest** and **Vue Test Utils** and live in `tests/unit/`, orga
 | `energy/` | The energy selector component and over-capacity logic |
 | `persistence/` | localStorage round-tripping and migration of older data |
 | `celebration/` | The useCelebration composable (messages, auto-dismiss, dismiss) and CelebrationPopup component |
+| `settings/` | The SettingsPanel component — structure, About section toggle, and close behaviour |
 
 Each feature folder has two files: one that tests the composable logic directly, and one that tests the components that render it. This split exists because the two test styles are technically incompatible — composable tests reset the module between each test to get fresh state, while component tests mock the composable entirely to isolate the component's rendering and event handling.
 
-There are 138 unit tests in total.
+There are 147 unit tests in total.
 
 ### End-to-end tests
 
@@ -120,8 +123,9 @@ End-to-end tests use **Playwright** and run against a real dev server. They live
 | `energy.spec.js` | Over-capacity filtering applied and removed reactively |
 | `persistence.spec.js` | Tasks, moves, edits, and energy level surviving a page reload |
 | `history.spec.js` | History panel opens, shows chart, shows best-week message |
+| `settings.spec.js` | Settings cog opens the panel; About toggles its content; close button and overlay dismiss the panel |
 
-Each test clears localStorage and reloads before it runs, so tests are fully independent. There are 62 end-to-end tests in total.
+Each test clears localStorage and reloads before it runs, so tests are fully independent. There are 69 end-to-end tests in total.
 
 ### CI
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,8 +5,10 @@ import EnergySelector from './components/EnergySelector.vue'
 import TaskBoard from './components/TaskBoard.vue'
 import HistoryPanel from './components/HistoryPanel.vue'
 import CelebrationPopup from './components/CelebrationPopup.vue'
+import SettingsPanel from './components/SettingsPanel.vue'
 
 const showHistory = ref(false)
+const showSettings = ref(false)
 </script>
 
 <template>
@@ -22,6 +24,12 @@ const showHistory = ref(false)
       <div class="app-controls">
         <button class="history-btn" @click="showHistory = true">History</button>
         <EnergySelector />
+        <button class="settings-btn" @click="showSettings = true" aria-label="Open settings">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M8 10a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z" stroke="currentColor" stroke-width="1.5"/>
+            <path d="M13.3 9.6a1 1 0 0 0 .2 1.1l.04.04a1.2 1.2 0 0 1-1.7 1.7l-.04-.04a1 1 0 0 0-1.1-.2 1 1 0 0 0-.6.92v.12a1.2 1.2 0 0 1-2.4 0v-.06a1 1 0 0 0-.66-.92 1 1 0 0 0-1.1.2l-.04.04a1.2 1.2 0 0 1-1.7-1.7l.04-.04a1 1 0 0 0 .2-1.1 1 1 0 0 0-.92-.6H3.2a1.2 1.2 0 0 1 0-2.4h.06a1 1 0 0 0 .92-.66 1 1 0 0 0-.2-1.1l-.04-.04a1.2 1.2 0 0 1 1.7-1.7l.04.04a1 1 0 0 0 1.1.2h.05A1 1 0 0 0 7.4 3.2V3.1a1.2 1.2 0 0 1 2.4 0v.06a1 1 0 0 0 .6.92 1 1 0 0 0 1.1-.2l.04-.04a1.2 1.2 0 0 1 1.7 1.7l-.04.04a1 1 0 0 0-.2 1.1v.05a1 1 0 0 0 .92.6h.12a1.2 1.2 0 0 1 0 2.4h-.06a1 1 0 0 0-.92.6Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
       </div>
     </header>
 
@@ -30,6 +38,7 @@ const showHistory = ref(false)
     </main>
 
     <HistoryPanel v-if="showHistory" @close="showHistory = false" />
+    <SettingsPanel v-if="showSettings" @close="showSettings = false" />
     <CelebrationPopup />
   </div>
 </template>
@@ -103,6 +112,26 @@ const showHistory = ref(false)
 }
 
 .history-btn:hover {
+  background: var(--border);
+  color: var(--text-h);
+}
+
+.settings-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 7px;
+  border: 1.5px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  flex-shrink: 0;
+}
+
+.settings-btn:hover {
   background: var(--border);
   color: var(--text-h);
 }

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -1,0 +1,240 @@
+<script setup>
+import { ref } from 'vue'
+
+defineEmits(['close'])
+
+const activeSection = ref(null)
+
+function toggleSection(section) {
+  activeSection.value = activeSection.value === section ? null : section
+}
+</script>
+
+<template>
+  <div class="settings-overlay" @click.self="$emit('close')">
+    <aside class="settings-panel">
+      <div class="settings-header">
+        <span class="settings-title">Settings</span>
+        <button class="settings-close" @click="$emit('close')" aria-label="Close settings">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+          </svg>
+        </button>
+      </div>
+
+      <nav class="settings-nav">
+        <button
+          class="settings-nav-item"
+          :class="{ active: activeSection === 'about' }"
+          @click="toggleSection('about')"
+        >
+          <svg class="nav-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.5"/>
+            <path d="M8 7v5M8 5v.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
+          About
+          <svg class="nav-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" :style="{ transform: activeSection === 'about' ? 'rotate(180deg)' : 'rotate(0deg)' }">
+            <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
+
+        <div v-if="activeSection === 'about'" class="settings-section-content">
+          <div class="about-content">
+            <p class="about-lead">
+              Untangle is a calm, energy-aware task manager designed to help you decide what to work on right now — without the overwhelm.
+            </p>
+            <div class="about-features">
+              <div class="about-feature">
+                <span class="feature-label">Three columns</span>
+                <span class="feature-desc">Organise tasks across <strong>Now</strong>, <strong>Next</strong>, and <strong>Future</strong> to keep your focus clear.</span>
+              </div>
+              <div class="about-feature">
+                <span class="feature-label">Energy levels</span>
+                <span class="feature-desc">Tag each task by how much effort it takes — Tiny, Small, Medium, or Large — so you can match tasks to how you feel.</span>
+              </div>
+              <div class="about-feature">
+                <span class="feature-label">Filter by energy</span>
+                <span class="feature-desc">Use the energy selector in the header to surface only the tasks that fit your current capacity.</span>
+              </div>
+              <div class="about-feature">
+                <span class="feature-label">History</span>
+                <span class="feature-desc">Completed tasks are saved so you can look back and see everything you've accomplished.</span>
+              </div>
+            </div>
+            <p class="about-footer">Your tasks are saved locally in your browser — nothing leaves your device.</p>
+          </div>
+        </div>
+      </nav>
+    </aside>
+  </div>
+</template>
+
+<style scoped>
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.25);
+  z-index: 50;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.settings-panel {
+  width: 320px;
+  max-width: 100vw;
+  height: 100%;
+  background: var(--bg);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.08);
+  animation: slide-in 0.18s ease-out;
+}
+
+@keyframes slide-in {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.settings-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-h);
+  letter-spacing: -0.2px;
+}
+
+.settings-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.settings-close:hover {
+  background: var(--border);
+  color: var(--text-h);
+}
+
+.settings-nav {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.settings-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 12px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 13.5px;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s, color 0.12s;
+}
+
+.settings-nav-item:hover {
+  background: var(--column-bg);
+  color: var(--text-h);
+}
+
+.settings-nav-item.active {
+  background: var(--column-bg);
+  color: var(--text-h);
+}
+
+.nav-icon {
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.nav-chevron {
+  margin-left: auto;
+  flex-shrink: 0;
+  opacity: 0.5;
+  transition: transform 0.15s ease;
+}
+
+.settings-section-content {
+  margin: 4px 0 8px;
+  padding: 0 4px;
+}
+
+.about-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 12px;
+  background: var(--column-bg);
+  border-radius: 8px;
+}
+
+.about-lead {
+  font-size: 13px;
+  color: var(--text-h);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.about-features {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.about-feature {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.feature-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.1px;
+}
+
+.feature-desc {
+  font-size: 12.5px;
+  color: var(--text);
+  line-height: 1.55;
+}
+
+.feature-desc strong {
+  color: var(--text-h);
+  font-weight: 600;
+}
+
+.about-footer {
+  font-size: 11.5px;
+  color: var(--text);
+  opacity: 0.7;
+  margin: 0;
+  line-height: 1.5;
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+</style>

--- a/tests/e2e/settings.spec.js
+++ b/tests/e2e/settings.spec.js
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('settings', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.evaluate(() => localStorage.clear())
+    await page.reload()
+  })
+
+  test('shows a settings button in the header', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /open settings/i })).toBeVisible()
+  })
+
+  test('clicking the settings button opens the settings panel', async ({ page }) => {
+    await page.getByRole('button', { name: /open settings/i }).click()
+    await expect(page.locator('.settings-panel')).toBeVisible()
+  })
+
+  test('the settings panel has an About item', async ({ page }) => {
+    await page.getByRole('button', { name: /open settings/i }).click()
+    await expect(page.locator('.settings-nav-item')).toContainText('About')
+  })
+
+  test('clicking About shows the about content', async ({ page }) => {
+    await page.getByRole('button', { name: /open settings/i }).click()
+    await page.locator('.settings-nav-item').click()
+    await expect(page.locator('.about-content')).toBeVisible()
+  })
+
+  test('clicking About again hides the about content', async ({ page }) => {
+    await page.getByRole('button', { name: /open settings/i }).click()
+    await page.locator('.settings-nav-item').click()
+    await page.locator('.settings-nav-item').click()
+    await expect(page.locator('.about-content')).not.toBeVisible()
+  })
+
+  test('the close button closes the panel', async ({ page }) => {
+    await page.getByRole('button', { name: /open settings/i }).click()
+    await page.locator('.settings-close').click()
+    await expect(page.locator('.settings-panel')).not.toBeVisible()
+  })
+
+  test('clicking the overlay closes the panel', async ({ page }) => {
+    await page.getByRole('button', { name: /open settings/i }).click()
+    await page.locator('.settings-overlay').click({ position: { x: 10, y: 300 } })
+    await expect(page.locator('.settings-panel')).not.toBeVisible()
+  })
+})

--- a/tests/unit/settings/components.test.js
+++ b/tests/unit/settings/components.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SettingsPanel from '../../../src/components/SettingsPanel.vue'
+
+describe('settings panel — components', () => {
+  describe('SettingsPanel — structure', () => {
+    it('renders the panel', () => {
+      const wrapper = mount(SettingsPanel)
+      expect(wrapper.find('.settings-panel').exists()).toBe(true)
+    })
+
+    it('shows "Settings" as the panel title', () => {
+      const wrapper = mount(SettingsPanel)
+      expect(wrapper.find('.settings-title').text()).toBe('Settings')
+    })
+
+    it('shows an About menu item', () => {
+      const wrapper = mount(SettingsPanel)
+      expect(wrapper.find('.settings-nav-item').text()).toContain('About')
+    })
+  })
+
+  describe('SettingsPanel — About section', () => {
+    it('hides the About content by default', () => {
+      const wrapper = mount(SettingsPanel)
+      expect(wrapper.find('.settings-section-content').exists()).toBe(false)
+    })
+
+    it('shows the About content when About is clicked', async () => {
+      const wrapper = mount(SettingsPanel)
+      await wrapper.find('.settings-nav-item').trigger('click')
+      expect(wrapper.find('.settings-section-content').exists()).toBe(true)
+    })
+
+    it('hides the About content when About is clicked a second time', async () => {
+      const wrapper = mount(SettingsPanel)
+      await wrapper.find('.settings-nav-item').trigger('click')
+      await wrapper.find('.settings-nav-item').trigger('click')
+      expect(wrapper.find('.settings-section-content').exists()).toBe(false)
+    })
+
+    it('shows descriptive text in the About section', async () => {
+      const wrapper = mount(SettingsPanel)
+      await wrapper.find('.settings-nav-item').trigger('click')
+      expect(wrapper.find('.about-lead').text()).toBeTruthy()
+    })
+  })
+
+  describe('SettingsPanel — close', () => {
+    it('emits close when the close button is clicked', async () => {
+      const wrapper = mount(SettingsPanel)
+      await wrapper.find('.settings-close').trigger('click')
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+
+    it('emits close when the overlay is clicked', async () => {
+      const wrapper = mount(SettingsPanel)
+      await wrapper.find('.settings-overlay').trigger('click')
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- **Settings button** — a cog icon in the top-right of the header, styled to match the existing History button
- **SettingsPanel component** — slides in from the right with a semi-transparent overlay; clicking the overlay or the × button closes it
- **About entry** — accordion-style item in the panel that expands to show a plain-language overview: the three columns, energy-level system, capacity filtering, history, and the fact that data stays local

## Tests

- `tests/unit/settings/components.test.js` — 9 unit tests covering structure, About toggle, and close events
- `tests/e2e/settings.spec.js` — 7 e2e tests covering the full open/close/About flow from the browser

All 147 unit tests pass.

## README

Updated to mention the settings cog in the feature description, and added both test files to the testing tables with revised counts (147 unit, 69 e2e).