### PR TITLE
Add dev server lifecycle hooks, CLAUDE.md, and persistence test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# Untangle — Claude Code guide
+
+## Dev server
+
+```
+npm run dev
+```
+
+Opens at `http://localhost:5173`. Vite's HMR reloads the browser on every save. A Claude Code hook in `~/.claude/settings.json` starts this automatically on the first file edit each session, so you usually don't need to run it manually.
+
+## Tests
+
+```
+npm test           # unit tests (Vitest, watch mode)
+npm run test:e2e   # end-to-end tests (Playwright, requires dev server running)
+```
+
+The E2E suite spins up its own dev server via `playwright.config.js`; you don't need to start one separately for it.
+
+## Architecture in brief
+
+All task state lives in `src/composables/useTasks.js` — a module-level singleton (Vue reactive refs outside the function). Every component that calls `useTasks()` shares the same state. `useCelebration.js` follows the same pattern for popup state.
+
+Components are thin: they call composable functions and render results. Business logic stays in the composables.
+
+## Test organisation
+
+Unit tests in `tests/unit/<feature>/` always come in pairs:
+- `composable.test.js` — resets the module between tests (`vi.resetModules()`) for fresh state
+- `components.test.js` — mocks the composable entirely (`vi.mock(...)`) to isolate rendering
+
+Don't mix the two styles in the same file — they're incompatible.
+
+E2E tests in `tests/e2e/` clear `localStorage` and reload before every test so they're fully independent.
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `src/composables/useTasks.js` | All task logic, energy filtering, localStorage persistence |
+| `src/composables/useCelebration.js` | Celebration popup state and messages |
+| `src/constants/energy.js` | Energy level definitions and column definitions |
+| `src/components/TaskCard.vue` | Display and edit mode for a single task |
+| `src/components/TaskColumn.vue` | Column with add-task form and drop zone |
+| `tests/e2e/helpers.js` | Shared Playwright helpers (`addTask`, `taskCard`, `openEdit`) |

--- a/tests/unit/persistence/composable.test.js
+++ b/tests/unit/persistence/composable.test.js
@@ -38,6 +38,7 @@ describe('persistence — composable', () => {
     expect(tasks.value[0].dueDate).toBeNull()
     expect(tasks.value[0].availableFrom).toBeNull()
     expect(tasks.value[0].subtasks).toEqual([])
+    expect(tasks.value[0].completedAt).toBeNull()
   })
 
   it('persists currentEnergy to localStorage', async () => {
@@ -45,6 +46,21 @@ describe('persistence — composable', () => {
     currentEnergy.value = 'large'
     await Promise.resolve()
     expect(localStorage.getItem('untangle-energy')).toBe('large')
+  })
+
+  it('loads currentEnergy from localStorage on init', async () => {
+    localStorage.setItem('untangle-energy', 'medium')
+    vi.resetModules()
+    const { useTasks: fresh } = await import('../../../src/composables/useTasks.js')
+    const { currentEnergy } = fresh()
+    expect(currentEnergy.value).toBe('medium')
+  })
+
+  it('restores currentEnergy as null when no energy is stored', async () => {
+    vi.resetModules()
+    const { useTasks: fresh } = await import('../../../src/composables/useTasks.js')
+    const { currentEnergy } = fresh()
+    expect(currentEnergy.value).toBeNull()
   })
 
   it('persists completedAt when a task is completed', async () => {


### PR DESCRIPTION
## Summary

- **Dev server lifecycle hooks** — two Claude Code hooks in `~/.claude/settings.json` manage the Vite dev server automatically: one starts it in the background on the first file edit each session (if not already running on port 5173), and one shuts it down after a `git push` so the server doesn't linger after work is merged and pushed
- **CLAUDE.md** — new file documenting the dev workflow (including the hooks), how to run tests, the composable singleton architecture, the paired composable/component test convention, and a key-files table
- **Persistence test gaps closed** — three tests added to `tests/unit/persistence/composable.test.js`:
  - `loads currentEnergy from localStorage on init` (the write-side was tested but not the read-back)
  - `restores currentEnergy as null when no energy is stored` (verifies the empty-string → null coercion)
  - `completedAt` assertion added to the existing migration test
- **`.gitignore`** — added `.claude/settings.local.json` so machine-specific Claude Code permission files are never accidentally committed

## Reviewer notes

The hook configuration lives in `~/.claude/settings.json` (user-level, outside the repo) rather than `.claude/settings.json`, so the hooks are not committed here — only their documentation in CLAUDE.md is. The `.gitignore` change ensures the local settings file that Claude Code auto-generates during sessions stays out of version control.