### PR TITLE
Reorganise header controls and convert About to a modal popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ When a task is done, you mark it complete with the ✓ button. It disappears fro
 
 The **History panel** (opened from the header) shows a bar chart of how many tasks you completed each week for the past four weeks, and calls out your most productive week ever.
 
-The **settings cog** (top-right corner) opens a side panel. The **About** entry gives a plain-language overview of what the app is and how it works.
+The **settings cog** (top-right corner) opens a side panel. Clicking the **About** entry opens a popup with a plain-language overview of what the app is and how it works.
 
 ### Task details
 
@@ -104,11 +104,11 @@ Unit tests use **Vitest** and **Vue Test Utils** and live in `tests/unit/`, orga
 | `energy/` | The energy selector component and over-capacity logic |
 | `persistence/` | localStorage round-tripping and migration of older data |
 | `celebration/` | The useCelebration composable (messages, auto-dismiss, dismiss) and CelebrationPopup component |
-| `settings/` | The SettingsPanel component — structure, About section toggle, and close behaviour |
+| `settings/` | The SettingsPanel component — structure, About modal, and close behaviour |
 
 Each feature folder has two files: one that tests the composable logic directly, and one that tests the components that render it. This split exists because the two test styles are technically incompatible — composable tests reset the module between each test to get fresh state, while component tests mock the composable entirely to isolate the component's rendering and event handling.
 
-There are 147 unit tests in total.
+There are 150 unit tests in total.
 
 ### End-to-end tests
 
@@ -123,9 +123,9 @@ End-to-end tests use **Playwright** and run against a real dev server. They live
 | `energy.spec.js` | Over-capacity filtering applied and removed reactively |
 | `persistence.spec.js` | Tasks, moves, edits, and energy level surviving a page reload |
 | `history.spec.js` | History panel opens, shows chart, shows best-week message |
-| `settings.spec.js` | Settings cog opens the panel; About toggles its content; close button and overlay dismiss the panel |
+| `settings.spec.js` | Settings cog opens the panel; About opens a modal; modal and panel close buttons work |
 
-Each test clears localStorage and reloads before it runs, so tests are fully independent. There are 69 end-to-end tests in total.
+Each test clears localStorage and reloads before it runs, so tests are fully independent. There are 70 end-to-end tests in total.
 
 ### CI
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,10 +20,10 @@ const showSettings = ref(false)
           <span class="app-title">untangle</span>
           <span class="app-tagline">A space to think</span>
         </div>
+        <EnergySelector />
       </div>
       <div class="app-controls">
         <button class="history-btn" @click="showHistory = true">History</button>
-        <EnergySelector />
         <button class="settings-btn" @click="showSettings = true" aria-label="Open settings">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
             <path d="M8 10a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z" stroke="currentColor" stroke-width="1.5"/>

--- a/src/components/EnergySelector.vue
+++ b/src/components/EnergySelector.vue
@@ -28,6 +28,9 @@ const { currentEnergy } = useTasks()
   display: flex;
   align-items: center;
   gap: 10px;
+  border: 1.5px solid var(--border);
+  border-radius: 9px;
+  padding: 4px 10px 4px 12px;
 }
 
 .energy-label {

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -3,11 +3,7 @@ import { ref } from 'vue'
 
 defineEmits(['close'])
 
-const activeSection = ref(null)
-
-function toggleSection(section) {
-  activeSection.value = activeSection.value === section ? null : section
-}
+const showAbout = ref(false)
 </script>
 
 <template>
@@ -23,49 +19,52 @@ function toggleSection(section) {
       </div>
 
       <nav class="settings-nav">
-        <button
-          class="settings-nav-item"
-          :class="{ active: activeSection === 'about' }"
-          @click="toggleSection('about')"
-        >
+        <button class="settings-nav-item" @click="showAbout = true">
           <svg class="nav-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
             <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.5"/>
             <path d="M8 7v5M8 5v.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
           </svg>
           About
-          <svg class="nav-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" :style="{ transform: activeSection === 'about' ? 'rotate(180deg)' : 'rotate(0deg)' }">
-            <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
         </button>
-
-        <div v-if="activeSection === 'about'" class="settings-section-content">
-          <div class="about-content">
-            <p class="about-lead">
-              Untangle is a calm, energy-aware task manager designed to help you decide what to work on right now — without the overwhelm.
-            </p>
-            <div class="about-features">
-              <div class="about-feature">
-                <span class="feature-label">Three columns</span>
-                <span class="feature-desc">Organise tasks across <strong>Now</strong>, <strong>Next</strong>, and <strong>Future</strong> to keep your focus clear.</span>
-              </div>
-              <div class="about-feature">
-                <span class="feature-label">Energy levels</span>
-                <span class="feature-desc">Tag each task by how much effort it takes — Tiny, Small, Medium, or Large — so you can match tasks to how you feel.</span>
-              </div>
-              <div class="about-feature">
-                <span class="feature-label">Filter by energy</span>
-                <span class="feature-desc">Use the energy selector in the header to surface only the tasks that fit your current capacity.</span>
-              </div>
-              <div class="about-feature">
-                <span class="feature-label">History</span>
-                <span class="feature-desc">Completed tasks are saved so you can look back and see everything you've accomplished.</span>
-              </div>
-            </div>
-            <p class="about-footer">Your tasks are saved locally in your browser — nothing leaves your device.</p>
-          </div>
-        </div>
       </nav>
     </aside>
+  </div>
+
+  <div v-if="showAbout" class="about-overlay" @click.self="showAbout = false">
+    <div class="about-modal">
+      <div class="about-modal-header">
+        <span class="about-modal-title">About Untangle</span>
+        <button class="about-modal-close" @click="showAbout = false" aria-label="Close about">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+          </svg>
+        </button>
+      </div>
+      <div class="about-content">
+        <p class="about-lead">
+          Untangle is a calm, energy-aware task manager designed to help you decide what to work on right now — without the overwhelm.
+        </p>
+        <div class="about-features">
+          <div class="about-feature">
+            <span class="feature-label">Three columns</span>
+            <span class="feature-desc">Organise tasks across <strong>Now</strong>, <strong>Next</strong>, and <strong>Future</strong> to keep your focus clear.</span>
+          </div>
+          <div class="about-feature">
+            <span class="feature-label">Energy levels</span>
+            <span class="feature-desc">Tag each task by how much effort it takes — Tiny, Small, Medium, or Large — so you can match tasks to how you feel.</span>
+          </div>
+          <div class="about-feature">
+            <span class="feature-label">Filter by energy</span>
+            <span class="feature-desc">Use the energy selector in the header to surface only the tasks that fit your current capacity.</span>
+          </div>
+          <div class="about-feature">
+            <span class="feature-label">History</span>
+            <span class="feature-desc">Completed tasks are saved so you can look back and see everything you've accomplished.</span>
+          </div>
+        </div>
+        <p class="about-footer">Your tasks are saved locally in your browser — nothing leaves your device.</p>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -160,35 +159,78 @@ function toggleSection(section) {
   color: var(--text-h);
 }
 
-.settings-nav-item.active {
-  background: var(--column-bg);
-  color: var(--text-h);
-}
-
 .nav-icon {
   flex-shrink: 0;
   opacity: 0.7;
 }
 
-.nav-chevron {
-  margin-left: auto;
-  flex-shrink: 0;
-  opacity: 0.5;
-  transition: transform 0.15s ease;
+/* About modal */
+
+.about-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
 }
 
-.settings-section-content {
-  margin: 4px 0 8px;
-  padding: 0 4px;
+.about-modal {
+  background: var(--bg);
+  border-radius: 12px;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.14), 0 0 0 1px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+  animation: modal-in 0.15s ease-out;
+}
+
+@keyframes modal-in {
+  from { transform: scale(0.96); opacity: 0; }
+  to   { transform: scale(1);    opacity: 1; }
+}
+
+.about-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.about-modal-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-h);
+  letter-spacing: -0.2px;
+}
+
+.about-modal-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.about-modal-close:hover {
+  background: var(--border);
+  color: var(--text-h);
 }
 
 .about-content {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding: 12px;
-  background: var(--column-bg);
-  border-radius: 8px;
+  padding: 20px;
 }
 
 .about-lead {

--- a/tests/e2e/settings.spec.js
+++ b/tests/e2e/settings.spec.js
@@ -21,17 +21,24 @@ test.describe('settings', () => {
     await expect(page.locator('.settings-nav-item')).toContainText('About')
   })
 
-  test('clicking About shows the about content', async ({ page }) => {
+  test('clicking About opens the About modal', async ({ page }) => {
     await page.getByRole('button', { name: /open settings/i }).click()
     await page.locator('.settings-nav-item').click()
-    await expect(page.locator('.about-content')).toBeVisible()
+    await expect(page.locator('.about-modal')).toBeVisible()
   })
 
-  test('clicking About again hides the about content', async ({ page }) => {
+  test('the About modal close button closes the modal', async ({ page }) => {
     await page.getByRole('button', { name: /open settings/i }).click()
     await page.locator('.settings-nav-item').click()
+    await page.locator('.about-modal-close').click()
+    await expect(page.locator('.about-modal')).not.toBeVisible()
+  })
+
+  test('clicking the About modal backdrop closes the modal', async ({ page }) => {
+    await page.getByRole('button', { name: /open settings/i }).click()
     await page.locator('.settings-nav-item').click()
-    await expect(page.locator('.about-content')).not.toBeVisible()
+    await page.locator('.about-overlay').click({ position: { x: 10, y: 10 } })
+    await expect(page.locator('.about-modal')).not.toBeVisible()
   })
 
   test('the close button closes the panel', async ({ page }) => {

--- a/tests/unit/settings/components.test.js
+++ b/tests/unit/settings/components.test.js
@@ -20,26 +20,33 @@ describe('settings panel — components', () => {
     })
   })
 
-  describe('SettingsPanel — About section', () => {
-    it('hides the About content by default', () => {
+  describe('SettingsPanel — About modal', () => {
+    it('hides the About modal by default', () => {
       const wrapper = mount(SettingsPanel)
-      expect(wrapper.find('.settings-section-content').exists()).toBe(false)
+      expect(wrapper.find('.about-overlay').exists()).toBe(false)
     })
 
-    it('shows the About content when About is clicked', async () => {
+    it('shows the About modal when About is clicked', async () => {
       const wrapper = mount(SettingsPanel)
       await wrapper.find('.settings-nav-item').trigger('click')
-      expect(wrapper.find('.settings-section-content').exists()).toBe(true)
+      expect(wrapper.find('.about-modal').exists()).toBe(true)
     })
 
-    it('hides the About content when About is clicked a second time', async () => {
+    it('hides the About modal when the modal close button is clicked', async () => {
       const wrapper = mount(SettingsPanel)
       await wrapper.find('.settings-nav-item').trigger('click')
-      await wrapper.find('.settings-nav-item').trigger('click')
-      expect(wrapper.find('.settings-section-content').exists()).toBe(false)
+      await wrapper.find('.about-modal-close').trigger('click')
+      expect(wrapper.find('.about-overlay').exists()).toBe(false)
     })
 
-    it('shows descriptive text in the About section', async () => {
+    it('hides the About modal when the backdrop is clicked', async () => {
+      const wrapper = mount(SettingsPanel)
+      await wrapper.find('.settings-nav-item').trigger('click')
+      await wrapper.find('.about-overlay').trigger('click')
+      expect(wrapper.find('.about-overlay').exists()).toBe(false)
+    })
+
+    it('shows descriptive text in the About modal', async () => {
       const wrapper = mount(SettingsPanel)
       await wrapper.find('.settings-nav-item').trigger('click')
       expect(wrapper.find('.about-lead').text()).toBeTruthy()


### PR DESCRIPTION
## Summary

- **Header layout**: EnergySelector moved from the right-side controls into the brand group, sitting immediately to the right of the "untangle" title. A subtle border now groups its fields visually. History button moved to sit immediately left of the settings cog.
- **About modal**: Clicking About in the settings panel now opens a centred modal popup instead of an inline accordion. The modal has its own close button and backdrop-click-to-close.

## Tests updated

- Unit tests: replaced inline-expand assertions (`.settings-section-content`, toggle-twice behaviour) with modal assertions (`.about-modal`, `.about-overlay`); added backdrop-click-to-close test
- E2E tests: same replacements; added backdrop-click-to-close test
- README test counts corrected (147 → 150 unit, 69 → 70 E2E)

## Reviewer notes

The About modal renders as a sibling of `.settings-overlay` in the template (Vue fragment), stacked at `z-index: 60` above the settings panel at `z-index: 50` — both remain visible simultaneously when About is open.