### PR TITLE
Add Tough Love button with anti-procrastination messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The **settings cog** (top-right corner) opens a side panel. Clicking the **About
 
 The **Encourage Me** button (next to the energy selector) displays a gentle, encouraging message in a toast notification at the bottom of the screen. Messages are written to be neurodivergent-friendly, with a low-pressure tone designed for people who may struggle with demand avoidance or executive dysfunction. There are 100 messages picked at random. The toast dismisses itself after five seconds, or can be clicked to dismiss it early.
 
+The **Tough Love** button (between Encourage Me and History) shows a firmer, more direct message in the same toast style. The messages are written to push back against procrastination without being harsh or demanding — an extra nudge rather than a critique. Clicking either button dismisses the other, so only one toast is ever shown at a time.
+
 ### Task details
 
 Each task supports:
@@ -66,7 +68,7 @@ The app is built with **Vue 3** and **Vite**, using no UI libraries, no router, 
 
 All task logic lives in a single composable (`useTasks.js`). This acts as a shared store — every component that calls it gets the same reactive state. It handles creating, editing, moving, completing, and deleting tasks, as well as tracking the current energy level.
 
-Notification state is split across two composables, both singletons. `useCelebration.js` handles task-completion messages: `showCelebration()` picks one of 50 messages at random and displays it as a full-screen centred popup for 3.5 seconds. `useEncouragement.js` handles the Encourage Me feature: `showEncouragement()` picks one of 100 neurodivergent-friendly messages at random and displays it as a bottom-centre toast for 5 seconds. Both dismiss early on click, and both cancel any running timer before starting a new one.
+Notification state is split across three composables, all singletons. `useCelebration.js` handles task-completion messages: `showCelebration()` picks one of 50 messages at random and displays it as a full-screen centred popup for 3.5 seconds. `useEncouragement.js` and `useToughLove.js` handle the header buttons: each picks one of 100 messages at random and displays it as a bottom-centre toast for 5 seconds. All three dismiss early on click and cancel any running timer before starting a new one. The two toast composables are coordinated in `App.vue` so that triggering one dismisses the other.
 
 Everything is saved to `localStorage` automatically whenever state changes, so nothing is lost on a page refresh. Completed tasks stay in storage (they're just hidden from the board columns) so the history panel can use them.
 
@@ -107,11 +109,12 @@ Unit tests use **Vitest** and **Vue Test Utils** and live in `tests/unit/`, orga
 | `persistence/` | localStorage round-tripping and migration of older data |
 | `celebration/` | The useCelebration composable (messages, auto-dismiss, dismiss) and CelebrationPopup component |
 | `encouragement/` | The useEncouragement composable (messages, auto-dismiss, dismiss) and EncouragementToast component |
+| `tough-love/` | The useToughLove composable (messages, auto-dismiss, dismiss) and ToughLoveToast component |
 | `settings/` | The SettingsPanel component — structure, About modal, and close behaviour |
 
 Each feature folder has two files: one that tests the composable logic directly, and one that tests the components that render it. This split exists because the two test styles are technically incompatible — composable tests reset the module between each test to get fresh state, while component tests mock the composable entirely to isolate the component's rendering and event handling.
 
-There are 165 unit tests in total.
+There are 180 unit tests in total.
 
 ### End-to-end tests
 
@@ -127,9 +130,10 @@ End-to-end tests use **Playwright** and run against a real dev server. They live
 | `persistence.spec.js` | Tasks, moves, edits, and energy level surviving a page reload |
 | `history.spec.js` | History panel opens, shows chart, shows best-week message |
 | `settings.spec.js` | Settings cog opens the panel; About opens a modal; modal and panel close buttons work |
-| `encouragement.spec.js` | Encourage Me button visibility, toast appearance, auto-dismiss, early dismiss |
+| `encouragement.spec.js` | Encourage Me button visibility, toast appearance, auto-dismiss, early dismiss, mutual dismiss with Tough Love |
+| `tough-love.spec.js` | Tough Love button visibility, toast appearance, auto-dismiss, early dismiss, mutual dismiss with Encourage Me |
 
-Each test clears localStorage and reloads before it runs, so tests are fully independent. There are 76 end-to-end tests in total.
+Each test clears localStorage and reloads before it runs, so tests are fully independent. There are 84 end-to-end tests in total.
 
 ### CI
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,12 +6,18 @@ import TaskBoard from './components/TaskBoard.vue'
 import HistoryPanel from './components/HistoryPanel.vue'
 import CelebrationPopup from './components/CelebrationPopup.vue'
 import EncouragementToast from './components/EncouragementToast.vue'
+import ToughLoveToast from './components/ToughLoveToast.vue'
 import SettingsPanel from './components/SettingsPanel.vue'
 import { useEncouragement } from './composables/useEncouragement.js'
+import { useToughLove } from './composables/useToughLove.js'
 
 const showHistory = ref(false)
 const showSettings = ref(false)
-const { showEncouragement } = useEncouragement()
+const { showEncouragement, dismissEncouragement } = useEncouragement()
+const { showToughLove, dismissToughLove } = useToughLove()
+
+function handleEncourage() { dismissToughLove(); showEncouragement() }
+function handleToughLove() { dismissEncouragement(); showToughLove() }
 </script>
 
 <template>
@@ -26,7 +32,8 @@ const { showEncouragement } = useEncouragement()
         <EnergySelector />
       </div>
       <div class="app-controls">
-        <button class="encourage-btn" @click="showEncouragement">Encourage Me</button>
+        <button class="encourage-btn" @click="handleEncourage">Encourage Me</button>
+        <button class="tough-love-btn" @click="handleToughLove">Tough Love</button>
         <button class="history-btn" @click="showHistory = true">History</button>
         <button class="settings-btn" @click="showSettings = true" aria-label="Open settings">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
@@ -45,6 +52,7 @@ const { showEncouragement } = useEncouragement()
     <SettingsPanel v-if="showSettings" @close="showSettings = false" />
     <CelebrationPopup />
     <EncouragementToast />
+    <ToughLoveToast />
   </div>
 </template>
 
@@ -97,7 +105,15 @@ const { showEncouragement } = useEncouragement()
   line-height: 1.2;
 }
 
-.encourage-btn {
+.app-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.encourage-btn,
+.tough-love-btn,
+.history-btn {
   padding: 5px 13px;
   border-radius: 7px;
   border: 1.5px solid var(--border);
@@ -111,30 +127,8 @@ const { showEncouragement } = useEncouragement()
   flex-shrink: 0;
 }
 
-.encourage-btn:hover {
-  background: var(--border);
-  color: var(--text-h);
-}
-
-.app-controls {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.history-btn {
-  padding: 5px 13px;
-  border-radius: 7px;
-  border: 1.5px solid var(--border);
-  background: transparent;
-  color: var(--text);
-  font-size: 13px;
-  font-family: inherit;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
-}
-
+.encourage-btn:hover,
+.tough-love-btn:hover,
 .history-btn:hover {
   background: var(--border);
   color: var(--text-h);

--- a/src/components/ToughLoveToast.vue
+++ b/src/components/ToughLoveToast.vue
@@ -1,0 +1,77 @@
+<script setup>
+import { useToughLove } from '../composables/useToughLove.js'
+
+const { toughLove, dismissToughLove } = useToughLove()
+</script>
+
+<template>
+  <Transition name="tough-love">
+    <div v-if="toughLove" class="tough-love-toast" @click="dismissToughLove">
+      <p class="tough-love-text">{{ toughLove }}</p>
+    </div>
+  </Transition>
+  <div class="sr-live" role="status" aria-live="polite" aria-atomic="true">
+    {{ toughLove || '' }}
+  </div>
+</template>
+
+<style scoped>
+.tough-love-toast {
+  position: fixed;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--card-bg);
+  border: 1.5px solid var(--border);
+  border-radius: 16px;
+  padding: 20px 28px;
+  max-width: min(440px, calc(100vw - 40px));
+  width: max-content;
+  text-align: center;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  cursor: pointer;
+  z-index: 9998;
+}
+
+.tough-love-text {
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--text-h);
+  margin: 0;
+  letter-spacing: -0.1px;
+}
+
+.sr-live {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tough-love-enter-active {
+  transition: opacity 0.22s ease, transform 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.tough-love-leave-active {
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.tough-love-enter-from {
+  opacity: 0;
+  transform: translateX(-50%) translateY(12px);
+}
+
+.tough-love-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(8px);
+}
+</style>

--- a/src/composables/useToughLove.js
+++ b/src/composables/useToughLove.js
@@ -1,0 +1,123 @@
+import { ref } from 'vue'
+
+export const TOUGH_LOVE_MESSAGES = [
+  "That task isn't going to do itself. Time to move.",
+  "You've been thinking about this long enough. Start now.",
+  "Done beats perfect. Get it moving.",
+  "Future you will be very grateful if present you just starts.",
+  "The hardest part is starting. You've stalled long enough.",
+  "Stop waiting to feel ready. You won't. Do it anyway.",
+  "This is the moment. Not later. Now.",
+  "You already know what needs to be done. Go do it.",
+  "You've got more capacity than you're giving yourself credit for.",
+  "How long has this been on your list? Exactly. Start.",
+  "The version of you who finished this task is waiting. Go meet them.",
+  "Your excuses are valid. And irrelevant. Do it anyway.",
+  "Progress is progress. Even slow is faster than still.",
+  "You are not as blocked as you think you are.",
+  "Pick it up. Just the first step. Go.",
+  "Waiting for motivation? It shows up after you start, not before.",
+  "The task is smaller than the dread. Trust that. Begin.",
+  "You've postponed this enough. Today's the day.",
+  "One small move beats zero big ones. Move.",
+  "You've handled harder things than this. Get on with it.",
+  "Stop overthinking. Start doing.",
+  "Not feeling it? Do it anyway. That's discipline.",
+  "The window of 'I'll do it later' is closing. Act now.",
+  "Every minute you delay costs future you. Start.",
+  "Two minutes of discomfort now beats hours of guilt later.",
+  "Get uncomfortable for ten minutes. That's all. Start.",
+  "You're not a passenger in your own life. Drive.",
+  "No one is coming to do this for you. Step up.",
+  "The version of you who finished this feels amazing. Be them.",
+  "Stop talking yourself out of it. Just begin.",
+  "Put down the distraction. Pick up the task.",
+  "You already decided this mattered. Act like it.",
+  "Resistance is highest before you start. Push through.",
+  "What would you do if you weren't afraid? Do that.",
+  "Time is not infinite. Use some of it on this.",
+  "You're closer to done than you think. Keep going.",
+  "Your future self deserves better than another delay.",
+  "The task didn't get easier from waiting. Start now.",
+  "You've survived every hard thing so far. This is manageable.",
+  "No more warm-up laps. This is the race. Run.",
+  "The best time to start was earlier. Second best is now.",
+  "You're capable. You're just choosing not to. Choose differently.",
+  "Energy follows action. Move first, feel motivated second.",
+  "You don't have to like it. You just have to do it.",
+  "Inaction is also a choice. Make a better one.",
+  "Five minutes. Just give it five honest minutes.",
+  "The longer you wait, the bigger it feels. Shrink it by starting.",
+  "What's the actual first step? Do that. Just that.",
+  "Your goal is waiting. What are you waiting for?",
+  "Hard tasks don't disappear. They just pile up. Deal with this one.",
+  "You're not going to regret doing it. You will regret not doing it.",
+  "Focus is a muscle. Work it.",
+  "Every day you delay is a day you're not moving forward.",
+  "Make the uncomfortable call. Send the difficult email. Do the thing.",
+  "The discomfort is temporary. The satisfaction lasts. Start.",
+  "You've been here before and you got through it. Same deal.",
+  "Stop letting perfect be the enemy of done.",
+  "Just because it's hard doesn't mean you can't do it.",
+  "Action over analysis. Every time. Let's go.",
+  "Your potential doesn't show up just by thinking about it.",
+  "You have a window right now. Use it before it closes.",
+  "Start messy. You can clean it up later.",
+  "Momentum is earned, not given. Earn some.",
+  "Clarity comes from doing, not from thinking about doing.",
+  "You'll feel better when it's done. So get it done.",
+  "The discomfort of starting is real. The regret of not starting is worse.",
+  "Push a little harder today. You'll thank yourself tonight.",
+  "Not in the mood? Great. Do it anyway and change your mood.",
+  "You've delayed the decision long enough. Make the call.",
+  "Effort now equals relief later. Simple math.",
+  "No one achieves anything significant without doing something uncomfortable.",
+  "You know what to do. The only question is when. Answer: now.",
+  "Stop rehearsing and start performing.",
+  "Be the person who finishes things. Start here.",
+  "Your energy isn't wasted on hard tasks. It's wasted on avoiding them.",
+  "This isn't about motivation. It's about commitment. Commit.",
+  "Small action, big impact. Even tiny movement counts. Go.",
+  "You've been giving yourself permission to wait. Revoke it.",
+  "The task requires less from you than your avoidance does.",
+  "Decide to be the kind of person who just handles things. Handle this.",
+  "Time passes either way. Use this next hour well.",
+  "You're procrastinating on purpose. Stop it.",
+  "What are you actually protecting yourself from? Just start.",
+  "One hour of real effort beats a day of half-effort. Give it that hour.",
+  "Progress feels better than comfort. Prove it to yourself.",
+  "You've got this. Now prove it.",
+  "The task is waiting. So is a better version of you. Let's go.",
+  "Good intentions don't move tasks. Action does.",
+  "That uneasy feeling? It's procrastination. Do the task and it goes away.",
+  "Checking your phone won't make the task smaller. Starting will.",
+  "You've been 'about to start' for a while now. Actually start.",
+  "The drag of avoidance is heavier than the weight of doing. Trust that.",
+  "Being busy with other things isn't the same as being done with this.",
+  "This task is on your list for a reason. That reason hasn't changed.",
+  "You already know this needs to happen. So make it happen.",
+  "Stop treating it like a suggestion. This is something you're doing.",
+  "The version of today that got this done feels lighter. Go be them.",
+  "You've stalled. That's fine. Now unstall.",
+  "Discomfort is the price of progress. You can afford it.",
+  "Look at the task. Now do the task. That's it.",
+]
+
+const toughLove = ref(null)
+let timer = null
+
+export function useToughLove() {
+  function showToughLove() {
+    const message = TOUGH_LOVE_MESSAGES[Math.floor(Math.random() * TOUGH_LOVE_MESSAGES.length)]
+    clearTimeout(timer)
+    toughLove.value = message
+    timer = setTimeout(() => { toughLove.value = null }, 5000)
+  }
+
+  function dismissToughLove() {
+    clearTimeout(timer)
+    toughLove.value = null
+  }
+
+  return { toughLove, showToughLove, dismissToughLove }
+}

--- a/tests/e2e/encouragement.spec.js
+++ b/tests/e2e/encouragement.spec.js
@@ -42,4 +42,12 @@ test.describe('Encourage Me', () => {
     await page.getByRole('button', { name: 'Encourage Me' }).click()
     await expect(page.locator('.encouragement-toast')).toBeVisible()
   })
+
+  test('clicking Encourage Me while Tough Love is showing replaces it', async ({ page }) => {
+    await page.getByRole('button', { name: 'Tough Love' }).click()
+    await expect(page.locator('.tough-love-toast')).toBeVisible()
+    await page.getByRole('button', { name: 'Encourage Me' }).click()
+    await expect(page.locator('.encouragement-toast')).toBeVisible()
+    await expect(page.locator('.tough-love-toast')).not.toBeVisible()
+  })
 })

--- a/tests/e2e/tough-love.spec.js
+++ b/tests/e2e/tough-love.spec.js
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Tough Love', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.evaluate(() => localStorage.clear())
+    await page.reload()
+  })
+
+  test('Tough Love button is visible in the header', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Tough Love' })).toBeVisible()
+  })
+
+  test('clicking Tough Love shows a toast notification', async ({ page }) => {
+    await page.getByRole('button', { name: 'Tough Love' }).click()
+    await expect(page.locator('.tough-love-toast')).toBeVisible()
+  })
+
+  test('toast displays a non-empty message', async ({ page }) => {
+    await page.getByRole('button', { name: 'Tough Love' }).click()
+    const text = await page.locator('.tough-love-text').textContent()
+    expect(text.trim().length).toBeGreaterThan(0)
+  })
+
+  test('toast auto-dismisses after 5 seconds', async ({ page }) => {
+    await page.getByRole('button', { name: 'Tough Love' }).click()
+    await expect(page.locator('.tough-love-toast')).toBeVisible()
+    await page.waitForTimeout(5100)
+    await expect(page.locator('.tough-love-toast')).not.toBeVisible()
+  })
+
+  test('clicking the toast dismisses it early', async ({ page }) => {
+    await page.getByRole('button', { name: 'Tough Love' }).click()
+    await expect(page.locator('.tough-love-toast')).toBeVisible()
+    await page.locator('.tough-love-toast').click()
+    await expect(page.locator('.tough-love-toast')).not.toBeVisible()
+  })
+
+  test('toast remains visible when button is clicked again', async ({ page }) => {
+    await page.getByRole('button', { name: 'Tough Love' }).click()
+    await expect(page.locator('.tough-love-toast')).toBeVisible()
+    await page.getByRole('button', { name: 'Tough Love' }).click()
+    await expect(page.locator('.tough-love-toast')).toBeVisible()
+  })
+
+  test('clicking Tough Love while Encourage Me is showing replaces it', async ({ page }) => {
+    await page.getByRole('button', { name: 'Encourage Me' }).click()
+    await expect(page.locator('.encouragement-toast')).toBeVisible()
+    await page.getByRole('button', { name: 'Tough Love' }).click()
+    await expect(page.locator('.tough-love-toast')).toBeVisible()
+    await expect(page.locator('.encouragement-toast')).not.toBeVisible()
+  })
+})

--- a/tests/unit/tough-love/components.test.js
+++ b/tests/unit/tough-love/components.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+
+const { mockDismissToughLove } = vi.hoisted(() => ({
+  mockDismissToughLove: vi.fn(),
+}))
+
+// eslint-disable-next-line no-var
+var mockToughLove
+
+vi.mock('../../../src/composables/useToughLove.js', () => {
+  mockToughLove = ref(null)
+  return {
+    useToughLove: () => ({
+      toughLove: mockToughLove,
+      showToughLove: vi.fn(),
+      dismissToughLove: mockDismissToughLove,
+    }),
+  }
+})
+
+import ToughLoveToast from '../../../src/components/ToughLoveToast.vue'
+
+describe('tough love toast — components', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockToughLove.value = null
+  })
+
+  describe('ToughLoveToast — visibility', () => {
+    it('renders nothing when toughLove is null', () => {
+      const wrapper = mount(ToughLoveToast)
+      expect(wrapper.find('.tough-love-toast').exists()).toBe(false)
+    })
+
+    it('renders the toast when there is a message', () => {
+      mockToughLove.value = 'Stop waiting. Start now.'
+      const wrapper = mount(ToughLoveToast)
+      expect(wrapper.find('.tough-love-toast').exists()).toBe(true)
+    })
+
+    it('displays the tough love message text', () => {
+      mockToughLove.value = 'Look at the task. Now do the task.'
+      const wrapper = mount(ToughLoveToast)
+      expect(wrapper.find('.tough-love-text').text()).toBe('Look at the task. Now do the task.')
+    })
+  })
+
+  describe('ToughLoveToast — dismiss', () => {
+    it('calls dismissToughLove when the toast is clicked', async () => {
+      mockToughLove.value = 'Stop waiting. Start now.'
+      const wrapper = mount(ToughLoveToast)
+      await wrapper.find('.tough-love-toast').trigger('click')
+      expect(mockDismissToughLove).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/tests/unit/tough-love/composable.test.js
+++ b/tests/unit/tough-love/composable.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+describe('useToughLove — composable', () => {
+  let useToughLove, TOUGH_LOVE_MESSAGES
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    ;({ useToughLove, TOUGH_LOVE_MESSAGES } = await import('../../../src/composables/useToughLove.js'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('initial state', () => {
+    it('toughLove starts as null', () => {
+      const { toughLove } = useToughLove()
+      expect(toughLove.value).toBeNull()
+    })
+  })
+
+  describe('showToughLove', () => {
+    it('sets toughLove to a non-empty string', () => {
+      const { toughLove, showToughLove } = useToughLove()
+      showToughLove()
+      expect(typeof toughLove.value).toBe('string')
+      expect(toughLove.value.length).toBeGreaterThan(0)
+    })
+
+    it('picks a message from the TOUGH_LOVE_MESSAGES list', () => {
+      const { toughLove, showToughLove } = useToughLove()
+      showToughLove()
+      expect(TOUGH_LOVE_MESSAGES).toContain(toughLove.value)
+    })
+
+    it('auto-dismisses after 5000ms', () => {
+      const { toughLove, showToughLove } = useToughLove()
+      showToughLove()
+      vi.advanceTimersByTime(5000)
+      expect(toughLove.value).toBeNull()
+    })
+
+    it('is still visible just before 5000ms', () => {
+      const { toughLove, showToughLove } = useToughLove()
+      showToughLove()
+      vi.advanceTimersByTime(4999)
+      expect(toughLove.value).not.toBeNull()
+    })
+
+    it('resets the auto-dismiss timer when called again', () => {
+      const { toughLove, showToughLove } = useToughLove()
+      showToughLove()
+      vi.advanceTimersByTime(4000)
+      showToughLove()
+      vi.advanceTimersByTime(4000)
+      expect(toughLove.value).not.toBeNull()
+      vi.advanceTimersByTime(1000)
+      expect(toughLove.value).toBeNull()
+    })
+  })
+
+  describe('dismissToughLove', () => {
+    it('clears the toughLove immediately', () => {
+      const { toughLove, showToughLove, dismissToughLove } = useToughLove()
+      showToughLove()
+      dismissToughLove()
+      expect(toughLove.value).toBeNull()
+    })
+
+    it('cancels the auto-dismiss timer', () => {
+      const { toughLove, showToughLove, dismissToughLove } = useToughLove()
+      showToughLove()
+      dismissToughLove()
+      vi.advanceTimersByTime(5000)
+      expect(toughLove.value).toBeNull()
+    })
+  })
+
+  describe('TOUGH_LOVE_MESSAGES', () => {
+    it('contains exactly 100 messages', () => {
+      expect(TOUGH_LOVE_MESSAGES).toHaveLength(100)
+    })
+
+    it('contains no duplicate messages', () => {
+      const unique = new Set(TOUGH_LOVE_MESSAGES)
+      expect(unique.size).toBe(TOUGH_LOVE_MESSAGES.length)
+    })
+
+    it('all messages are non-empty strings', () => {
+      for (const msg of TOUGH_LOVE_MESSAGES) {
+        expect(typeof msg).toBe('string')
+        expect(msg.trim().length).toBeGreaterThan(0)
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a **Tough Love** button to the header, between Encourage Me and History
- Clicking it shows a bottom-centre toast with one of 100 firm-but-kind messages designed to push back against procrastination — firmer in tone than Encourage Me but not harsh or demanding
- The two toast buttons are **mutually exclusive**: clicking one dismisses the other, so only one toast is ever visible at a time

## Implementation

Follows the identical pattern established by Encourage Me:

- `src/composables/useToughLove.js` — singleton composable with `showToughLove()` and `dismissToughLove()`, 5-second auto-dismiss, timer reset on re-trigger
- `src/components/ToughLoveToast.vue` — bottom-centre toast, same structure and animations as `EncouragementToast.vue`
- Mutual dismissal coordinated in `App.vue`, which already imports both composables — no circular dependencies

Also tidies up two issues flagged in code review:
- Consolidates three identical header button CSS blocks into one shared rule in `App.vue`
- Updates `README.md` with feature description, architecture notes, and revised test counts (180 unit, 84 E2E)

## Test plan

- [ ] Unit tests: composable (9 tests) and component (4 tests) — mirrors encouragement test suite exactly
- [ ] E2E tests: button visibility, toast appearance, auto-dismiss, early dismiss, mutual dismissal in both directions (7 tests)
- [ ] All 180 unit tests pass
- [ ] All 84 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)