### PR TITLE
Trim README: replace duplicate detail with wiki links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,31 +12,13 @@ Tasks are organised across three columns:
 - **Next** — what's coming up
 - **Future** — everything else, parked without pressure
 
-Each task can have an **energy level** (tiny, small, medium, or large). You set your current energy in the header, and any task that needs more energy than you have right now is faded out — still visible, but clearly deprioritised. When you haven't set your energy for the day, nothing is faded.
+Each task can have an **energy level** (tiny, small, medium, or large). You set your current energy in the header, and any task that needs more energy than you have right now is faded out — still visible, but clearly deprioritised.
 
-When a task is done, you mark it complete with the ✓ button. It disappears from the board, a celebration popup appears in the centre of the screen, and the task is remembered for your history.
+When a task is done, you mark it complete. It disappears from the board, a celebration popup appears, and the task is remembered for your history.
 
-The **History panel** (opened from the header) shows a bar chart of how many tasks you completed each week for the past four weeks, and calls out your most productive week ever.
+Each task supports a title, energy level, due date, available-from date, and subtasks. All fields can be set on creation and edited afterwards. Tasks can be moved between columns with the **← →** arrow buttons or by drag and drop.
 
-The **settings cog** (top-right corner) opens a side panel. Clicking the **About** entry opens a popup with a plain-language overview of what the app is and how it works.
-
-The **Encourage Me** button (next to the energy selector) displays a gentle, encouraging message in a toast notification at the bottom of the screen. Messages are written to be neurodivergent-friendly, with a low-pressure tone designed for people who may struggle with demand avoidance or executive dysfunction. There are 100 messages picked at random. The toast dismisses itself after five seconds, or can be clicked to dismiss it early.
-
-### Task details
-
-Each task supports:
-
-- **Title** (required)
-- **Energy level** — optional, used for the capacity filter
-- **Due date** — shown as a date chip on the card; overdue tasks are highlighted
-- **Available from date** — for tasks you can't start yet
-- **Subtasks** — a checklist with a progress bar (e.g. 2/5 complete)
-
-All of these can be set when creating a task and edited afterwards.
-
-### Moving tasks
-
-Tasks can be moved between columns using the **← →** arrow buttons on each card, or by **dragging and dropping** them into any column.
+The header also has an **Encourage Me** button (gentle, low-pressure messages) and a **Tough Love** button (firm-but-kind pushback against procrastination) — both appear as toasts and are mutually exclusive.
 
 ## Why it exists
 
@@ -58,79 +40,19 @@ Open `http://localhost:5173` in your browser. No account or internet connection 
 
 ## How it's built
 
-### Technology
+Vue 3 + Vite, no UI framework, plain CSS with custom properties for theming. All task state lives in a single composable (`useTasks.js`) that acts as a module-level singleton — every component that calls it shares the same reactive refs. Notification state (celebration, encouragement, tough love) follows the same pattern in separate composables. Everything is saved to `localStorage` automatically on every state change.
 
-The app is built with **Vue 3** and **Vite**, using no UI libraries, no router, and no external state management — the scope doesn't require them. Styling is done entirely in CSS using custom properties, with light and dark mode handled automatically based on system preference.
-
-### State and data
-
-All task logic lives in a single composable (`useTasks.js`). This acts as a shared store — every component that calls it gets the same reactive state. It handles creating, editing, moving, completing, and deleting tasks, as well as tracking the current energy level.
-
-Notification state is split across two composables, both singletons. `useCelebration.js` handles task-completion messages: `showCelebration()` picks one of 50 messages at random and displays it as a full-screen centred popup for 3.5 seconds. `useEncouragement.js` handles the Encourage Me feature: `showEncouragement()` picks one of 100 neurodivergent-friendly messages at random and displays it as a bottom-centre toast for 5 seconds. Both dismiss early on click, and both cancel any running timer before starting a new one.
-
-Everything is saved to `localStorage` automatically whenever state changes, so nothing is lost on a page refresh. Completed tasks stay in storage (they're just hidden from the board columns) so the history panel can use them.
-
-### Energy filtering
-
-Energy levels have a numeric rank from 1 (tiny) to 4 (large). When you set your current energy, any task whose required energy is higher gets a reduced opacity. If you haven't set an energy level, nothing is filtered. The filtering is reactive — it updates immediately as you change your energy.
-
-### Drag and drop
-
-Drag and drop uses the browser's built-in drag-and-drop API with no external libraries. Dragging is disabled while a task is in edit mode.
-
-### History panel
-
-The History panel groups completed tasks by week (Monday–Sunday) and displays the count for each of the past four weeks as a bar chart. It also scans all completed tasks ever to find and display the most productive week.
+→ [Architecture](https://github.com/lauz9888/untangle/wiki/Architecture) and [Data Model](https://github.com/lauz9888/untangle/wiki/Data-Model) in the wiki cover the design in detail.
 
 ---
 
 ## Testing
 
-### Running tests
-
 ```bash
-npm test           # Unit tests (watch mode)
-npm run test:e2e   # End-to-end tests
+npm test           # unit tests (Vitest, watch mode)
+npm run test:e2e   # end-to-end tests (Playwright)
 ```
 
-### Unit tests
+Unit tests cover composable logic and component rendering in isolation. E2E tests cover complete user workflows in a real browser, including drag-and-drop, localStorage persistence across reloads, and real timer behaviour. Tests run automatically on every push via GitHub Actions.
 
-Unit tests use **Vitest** and **Vue Test Utils** and live in `tests/unit/`, organised into subdirectories by feature:
-
-| Folder | What it covers |
-|---|---|
-| `task-management/` | Creating, deleting, updating, and completing tasks |
-| `task-movement/` | Moving tasks between columns (arrow buttons and direct column moves) |
-| `task-editing/` | The inline edit form — pre-filling, saving, cancelling |
-| `subtasks/` | Adding, removing, and toggling subtasks |
-| `energy/` | The energy selector component and over-capacity logic |
-| `persistence/` | localStorage round-tripping and migration of older data |
-| `celebration/` | The useCelebration composable (messages, auto-dismiss, dismiss) and CelebrationPopup component |
-| `encouragement/` | The useEncouragement composable (messages, auto-dismiss, dismiss) and EncouragementToast component |
-| `settings/` | The SettingsPanel component — structure, About modal, and close behaviour |
-
-Each feature folder has two files: one that tests the composable logic directly, and one that tests the components that render it. This split exists because the two test styles are technically incompatible — composable tests reset the module between each test to get fresh state, while component tests mock the composable entirely to isolate the component's rendering and event handling.
-
-There are 165 unit tests in total.
-
-### End-to-end tests
-
-End-to-end tests use **Playwright** and run against a real dev server. They live in `tests/e2e/`, one file per feature area:
-
-| File | What it covers |
-|---|---|
-| `layout.spec.js` | Page structure, column headers, energy buttons, defaults |
-| `task-management.spec.js` | Adding, deleting, completing tasks, and the celebration popup |
-| `task-editing.spec.js` | Editing task title, energy, dates, and subtasks |
-| `task-movement.spec.js` | Arrow buttons and drag-and-drop between columns |
-| `energy.spec.js` | Over-capacity filtering applied and removed reactively |
-| `persistence.spec.js` | Tasks, moves, edits, and energy level surviving a page reload |
-| `history.spec.js` | History panel opens, shows chart, shows best-week message |
-| `settings.spec.js` | Settings cog opens the panel; About opens a modal; modal and panel close buttons work |
-| `encouragement.spec.js` | Encourage Me button visibility, toast appearance, auto-dismiss, early dismiss |
-
-Each test clears localStorage and reloads before it runs, so tests are fully independent. There are 76 end-to-end tests in total.
-
-### CI
-
-Tests run automatically on every push via GitHub Actions, in three parallel jobs: unit tests, end-to-end tests, and a production build check.
+→ [Testing](https://github.com/lauz9888/untangle/wiki/Testing) in the wiki explains the coverage approach and what sits at each level.


### PR DESCRIPTION
## Summary

- Removes the full \"How it's built\" and \"Testing\" sections from the README — this content is already covered in depth in the wiki (Architecture, Data Model, Testing pages)
- Replaces each with a short one-paragraph summary and a direct link to the relevant wiki page
- Also adds the Tough Love button to the feature list in the README, which was missing

## Why

The README and wiki had grown out of sync, with the README duplicating large sections of the wiki in less detail. The README's job is to answer \"what is this and how do I run it\" for anyone landing on the repo; the wiki is the contributor reference. Keeping both in sync was going to be ongoing friction.

## Reviewer notes

No code changes — README only. The wiki itself was updated directly (it lives in a separate git repo at `lauz9888/untangle.wiki.git`) and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)