### PR TITLE
Add streak tracker with configurable exclusion rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The E2E suite spins up its own dev server via `playwright.config.js`; you don't 
 
 ## Architecture in brief
 
-All task state lives in `src/composables/useTasks.js` — a module-level singleton (Vue reactive refs outside the function). Every component that calls `useTasks()` shares the same state. `useCelebration.js` follows the same pattern for popup state.
+All task state lives in `src/composables/useTasks.js` — a module-level singleton (Vue reactive refs outside the function). Every component that calls `useTasks()` shares the same state. `useCelebration.js`, `useEncouragement.js`, `useToughLove.js`, and `useStreak.js` follow the same singleton pattern.
 
 Components are thin: they call composable functions and render results. Business logic stays in the composables.
 
@@ -38,6 +38,7 @@ E2E tests in `tests/e2e/` clear `localStorage` and reload before every test so t
 | File | Purpose |
 |---|---|
 | `src/composables/useTasks.js` | All task logic, energy filtering, localStorage persistence |
+| `src/composables/useStreak.js` | Streak counter logic, exclusion rules, settings persistence |
 | `src/composables/useCelebration.js` | Celebration popup state and messages |
 | `src/constants/energy.js` | Energy level definitions and column definitions |
 | `src/components/TaskCard.vue` | Display and edit mode for a single task |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ When a task is done, you mark it complete with the ✓ button. It disappears fro
 
 The **History panel** (opened from the header) shows a bar chart of how many tasks you completed each week for the past four weeks, and calls out your most productive week ever.
 
-The **settings cog** (top-right corner) opens a side panel. Clicking the **About** entry opens a popup with a plain-language overview of what the app is and how it works.
+The **streak counter** (in the header, next to the controls) shows how many days in a row you've completed at least one task. It increments on the first completion of each new day and resets if a full active day passes with nothing completed. The flame icon glows when the streak is active.
+
+The **settings cog** (top-right corner) opens a side panel. Clicking the **About** entry opens a popup with a plain-language overview of what the app is and how it works. The **Streak** section lets you configure three independent exclusion rules:
+
+- **Exclude weekends** — Saturday and Sunday don't count against (or towards) your streak; they're skipped entirely when checking for gaps or recording completions.
+- **Exclude UK bank holidays** — England and Wales public holidays (2024–2028) are treated the same way.
+- **Streak freeze** — pause the streak until a chosen date. Days up to and including that date are skipped, so a gap over a holiday or period away won't break your streak. The first active day after the freeze is the next required completion.
 
 The **Encourage Me** button (next to the energy selector) displays a gentle, encouraging message in a toast notification at the bottom of the screen. Messages are written to be neurodivergent-friendly, with a low-pressure tone designed for people who may struggle with demand avoidance or executive dysfunction. There are 100 messages picked at random. The toast dismisses itself after five seconds, or can be clicked to dismiss it early.
 
@@ -70,6 +76,8 @@ All task logic lives in a single composable (`useTasks.js`). This acts as a shar
 
 Notification state is split across three composables, all singletons. `useCelebration.js` handles task-completion messages: `showCelebration()` picks one of 50 messages at random and displays it as a full-screen centred popup for 3.5 seconds. `useEncouragement.js` and `useToughLove.js` handle the header buttons: each picks one of 100 messages at random and displays it as a bottom-centre toast for 5 seconds. All three dismiss early on click and cancel any running timer before starting a new one. The two toast composables are coordinated in `App.vue` so that triggering one dismisses the other.
 
+Streak state lives in `useStreak.js`, another module-level singleton. It exposes `streakCount` (a computed ref) and `streakSettings` (a reactive ref persisted to localStorage). `recordCompletion()` is called inside `useTasks.js` whenever a task is completed; it increments the count if no active day was missed since the last completion, or resets to 1 if a gap is detected. Excluded days (weekends, bank holidays, freeze period) are transparent to both the gap check and the increment check — they're simply not counted in either direction. A reactive `today` ref, updated by a self-rescheduling `setTimeout` at local midnight, ensures the streak count recomputes automatically when the date rolls over.
+
 Everything is saved to `localStorage` automatically whenever state changes, so nothing is lost on a page refresh. Completed tasks stay in storage (they're just hidden from the board columns) so the history panel can use them.
 
 ### Energy filtering
@@ -111,10 +119,11 @@ Unit tests use **Vitest** and **Vue Test Utils** and live in `tests/unit/`, orga
 | `encouragement/` | The useEncouragement composable (messages, auto-dismiss, dismiss) and EncouragementToast component |
 | `tough-love/` | The useToughLove composable (messages, auto-dismiss, dismiss) and ToughLoveToast component |
 | `settings/` | The SettingsPanel component — structure, About modal, and close behaviour |
+| `streak/` | The useStreak composable (count logic, all three exclusion types, persistence, midnight rollover) and the streak display in App.vue and settings in SettingsPanel |
 
 Each feature folder has two files: one that tests the composable logic directly, and one that tests the components that render it. This split exists because the two test styles are technically incompatible — composable tests reset the module between each test to get fresh state, while component tests mock the composable entirely to isolate the component's rendering and event handling.
 
-There are 180 unit tests in total.
+There are 231 unit tests in total.
 
 ### End-to-end tests
 
@@ -132,8 +141,9 @@ End-to-end tests use **Playwright** and run against a real dev server. They live
 | `settings.spec.js` | Settings cog opens the panel; About opens a modal; modal and panel close buttons work |
 | `encouragement.spec.js` | Encourage Me button visibility, toast appearance, auto-dismiss, early dismiss, mutual dismiss with Tough Love |
 | `tough-love.spec.js` | Tough Love button visibility, toast appearance, auto-dismiss, early dismiss, mutual dismiss with Encourage Me |
+| `streak.spec.js` | Streak display, increment on completion, same-day no-op, existing streak from storage, persistence, settings panel UI, freeze date picker, settings persistence |
 
-Each test clears localStorage and reloads before it runs, so tests are fully independent. There are 84 end-to-end tests in total.
+Each test clears localStorage and reloads before it runs, so tests are fully independent. There are 106 end-to-end tests in total.
 
 ### CI
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,11 +10,13 @@ import ToughLoveToast from './components/ToughLoveToast.vue'
 import SettingsPanel from './components/SettingsPanel.vue'
 import { useEncouragement } from './composables/useEncouragement.js'
 import { useToughLove } from './composables/useToughLove.js'
+import { useStreak } from './composables/useStreak.js'
 
 const showHistory = ref(false)
 const showSettings = ref(false)
 const { showEncouragement, dismissEncouragement } = useEncouragement()
 const { showToughLove, dismissToughLove } = useToughLove()
+const { streakCount } = useStreak()
 
 function handleEncourage() { dismissToughLove(); showEncouragement() }
 function handleToughLove() { dismissEncouragement(); showToughLove() }
@@ -32,6 +34,10 @@ function handleToughLove() { dismissEncouragement(); showToughLove() }
         <EnergySelector />
       </div>
       <div class="app-controls">
+        <div class="streak-display" :class="{ 'streak-active': streakCount > 0 }" title="Days in a row you've completed a task">
+          <span class="streak-icon">🔥</span>
+          <span class="streak-text">{{ streakCount }} {{ streakCount === 1 ? 'day' : 'days' }}</span>
+        </div>
         <button class="encourage-btn" @click="handleEncourage">Encourage Me</button>
         <button class="tough-love-btn" @click="handleToughLove">Tough Love</button>
         <button class="history-btn" @click="showHistory = true">History</button>
@@ -109,6 +115,35 @@ function handleToughLove() { dismissEncouragement(); showToughLove() }
   display: flex;
   align-items: center;
   gap: 12px;
+}
+
+.streak-display {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 7px;
+  border: 1.5px solid var(--border);
+  font-size: 13px;
+  color: var(--text);
+  opacity: 0.5;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.streak-display.streak-active {
+  opacity: 1;
+  border-color: #f97316;
+  color: var(--text-h);
+}
+
+.streak-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.streak-text {
+  font-variant-numeric: tabular-nums;
 }
 
 .encourage-btn,

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -1,9 +1,23 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useStreak, todayString } from '../composables/useStreak.js'
 
 defineEmits(['close'])
 
 const showAbout = ref(false)
+const { streakSettings } = useStreak()
+
+const freezeEnabled = computed({
+  get: () => !!streakSettings.value.freezeUntil,
+  set: (val) => {
+    if (val) {
+      streakSettings.value.freezeUntil = streakSettings.value.freezeUntil || todayString()
+    } else {
+      streakSettings.value.freezeUntil = null
+    }
+  },
+})
+
 </script>
 
 <template>
@@ -18,15 +32,73 @@ const showAbout = ref(false)
         </button>
       </div>
 
-      <nav class="settings-nav">
-        <button class="settings-nav-item" @click="showAbout = true">
-          <svg class="nav-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
-            <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.5"/>
-            <path d="M8 7v5M8 5v.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-          </svg>
-          About
-        </button>
-      </nav>
+      <div class="settings-body">
+        <nav class="settings-nav">
+          <button class="settings-nav-item" @click="showAbout = true">
+            <svg class="nav-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.5"/>
+              <path d="M8 7v5M8 5v.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+            About
+          </button>
+        </nav>
+
+        <div class="settings-divider" />
+
+        <section class="settings-section">
+          <div class="section-title">Streak</div>
+
+          <label class="toggle-row">
+            <span class="toggle-label">
+              <span class="toggle-name">Exclude weekends</span>
+              <span class="toggle-desc">Sat &amp; Sun don't count against your streak</span>
+            </span>
+            <input
+              type="checkbox"
+              class="toggle-switch"
+              v-model="streakSettings.excludeWeekends"
+              aria-label="Exclude weekends from streak"
+            />
+          </label>
+
+          <label class="toggle-row">
+            <span class="toggle-label">
+              <span class="toggle-name">Exclude UK bank holidays</span>
+              <span class="toggle-desc">England &amp; Wales public holidays are skipped</span>
+            </span>
+            <input
+              type="checkbox"
+              class="toggle-switch"
+              v-model="streakSettings.excludeBankHolidays"
+              aria-label="Exclude UK bank holidays from streak"
+            />
+          </label>
+
+          <label class="toggle-row">
+            <span class="toggle-label">
+              <span class="toggle-name">Streak freeze</span>
+              <span class="toggle-desc">Pause your streak until a chosen date</span>
+            </span>
+            <input
+              type="checkbox"
+              class="toggle-switch"
+              v-model="freezeEnabled"
+              aria-label="Enable streak freeze"
+            />
+          </label>
+
+          <div v-if="freezeEnabled" class="freeze-date-row">
+            <label class="freeze-date-label" for="freeze-until">Frozen until</label>
+            <input
+              id="freeze-until"
+              type="date"
+              class="freeze-date-input"
+              :value="streakSettings.freezeUntil"
+              @change="streakSettings.freezeUntil = $event.target.value"
+            />
+          </div>
+        </section>
+      </div>
     </aside>
   </div>
 
@@ -130,9 +202,150 @@ const showAbout = ref(false)
   color: var(--text-h);
 }
 
-.settings-nav {
+.settings-body {
   flex: 1;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Streak section */
+
+.settings-section {
+  padding: 16px 16px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.section-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text);
+  opacity: 0.5;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  padding: 0 4px 8px;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 4px;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background 0.1s;
+}
+
+.toggle-row:hover {
+  background: var(--column-bg);
+}
+
+.toggle-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.toggle-name {
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--text-h);
+  line-height: 1.3;
+}
+
+.toggle-desc {
+  font-size: 11.5px;
+  color: var(--text);
+  opacity: 0.65;
+  line-height: 1.35;
+}
+
+/* Toggle switch */
+.toggle-switch {
+  appearance: none;
+  -webkit-appearance: none;
+  flex-shrink: 0;
+  width: 36px;
+  height: 22px;
+  border-radius: 11px;
+  background: var(--border);
+  cursor: pointer;
+  position: relative;
+  transition: background 0.18s;
+  outline: none;
+}
+
+.toggle-switch::after {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  background: white;
+  top: 2px;
+  left: 2px;
+  transition: transform 0.18s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-switch:checked {
+  background: var(--accent);
+}
+
+.toggle-switch:checked::after {
+  transform: translateX(14px);
+}
+
+.toggle-switch:focus-visible {
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
+/* Freeze date picker */
+.freeze-date-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 4px 10px 4px;
+  gap: 12px;
+}
+
+.freeze-date-label {
+  font-size: 12.5px;
+  color: var(--text);
+  opacity: 0.75;
+}
+
+.freeze-date-input {
+  font-family: inherit;
+  font-size: 12.5px;
+  color: var(--text-h);
+  background: var(--column-bg);
+  border: 1.5px solid var(--border);
+  border-radius: 7px;
+  padding: 4px 8px;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.12s;
+}
+
+.freeze-date-input:focus {
+  border-color: var(--accent);
+}
+
+.settings-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+  flex-shrink: 0;
+}
+
+/* Nav (About) */
+
+.settings-nav {
   padding: 8px;
 }
 

--- a/src/composables/useStreak.js
+++ b/src/composables/useStreak.js
@@ -1,0 +1,137 @@
+import { ref, computed, watch } from 'vue'
+
+const STREAK_KEY = 'untangle-streak'
+const STREAK_SETTINGS_KEY = 'untangle-streak-settings'
+
+// England & Wales bank holidays 2024–2028
+const UK_BANK_HOLIDAYS = new Set([
+  // 2024
+  '2024-01-01', '2024-03-29', '2024-04-01', '2024-05-06',
+  '2024-05-27', '2024-08-26', '2024-12-25', '2024-12-26',
+  // 2025
+  '2025-01-01', '2025-04-18', '2025-04-21', '2025-05-05',
+  '2025-05-26', '2025-08-25', '2025-12-25', '2025-12-26',
+  // 2026
+  '2026-01-01', '2026-04-03', '2026-04-06', '2026-05-04',
+  '2026-05-25', '2026-08-31', '2026-12-25', '2026-12-28',
+  // 2027
+  '2027-01-01', '2027-03-26', '2027-03-29', '2027-05-03',
+  '2027-05-31', '2027-08-30', '2027-12-27', '2027-12-28',
+  // 2028
+  '2028-01-03', '2028-04-14', '2028-04-17', '2028-05-01',
+  '2028-05-29', '2028-08-28', '2028-12-25', '2028-12-26',
+])
+
+function toDateString(date) {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+export function todayString() {
+  return toDateString(new Date())
+}
+
+function addDays(dateStr, n) {
+  const d = new Date(dateStr + 'T00:00:00')
+  d.setDate(d.getDate() + n)
+  return toDateString(d)
+}
+
+function isWeekend(dateStr) {
+  const day = new Date(dateStr + 'T00:00:00').getDay()
+  return day === 0 || day === 6
+}
+
+function isExcluded(dateStr, settings) {
+  if (settings.excludeWeekends && isWeekend(dateStr)) return true
+  if (settings.excludeBankHolidays && UK_BANK_HOLIDAYS.has(dateStr)) return true
+  if (settings.freezeUntil && dateStr <= settings.freezeUntil) return true
+  return false
+}
+
+// Most recent non-excluded day strictly before dateStr (up to 730 days back)
+function prevActiveDay(dateStr, settings) {
+  let d = addDays(dateStr, -1)
+  for (let i = 0; i < 730; i++) {
+    if (!isExcluded(d, settings)) return d
+    d = addDays(d, -1)
+  }
+  return null
+}
+
+// True if any non-excluded day falls strictly between fromDate and toDate
+function hasActiveDayBetween(fromDate, toDate, settings) {
+  let d = addDays(fromDate, 1)
+  while (d < toDate) {
+    if (!isExcluded(d, settings)) return true
+    d = addDays(d, 1)
+  }
+  return false
+}
+
+function loadStreak() {
+  try {
+    const val = localStorage.getItem(STREAK_KEY)
+    if (!val) return { count: 0, lastCompletedDate: null }
+    return JSON.parse(val)
+  } catch {
+    return { count: 0, lastCompletedDate: null }
+  }
+}
+
+function loadStreakSettings() {
+  try {
+    const val = localStorage.getItem(STREAK_SETTINGS_KEY)
+    if (!val) return { excludeWeekends: false, excludeBankHolidays: false, freezeUntil: null }
+    return JSON.parse(val)
+  } catch {
+    return { excludeWeekends: false, excludeBankHolidays: false, freezeUntil: null }
+  }
+}
+
+const streakData = ref(loadStreak())
+const streakSettings = ref(loadStreakSettings())
+
+// Reactive today — updated at each midnight so streakCount recomputes on date rollover
+const today = ref(todayString())
+;(function scheduleMidnightUpdate() {
+  const now = new Date()
+  const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1)
+  setTimeout(() => {
+    today.value = todayString()
+    scheduleMidnightUpdate()
+  }, midnight.getTime() - now.getTime())
+})()
+
+watch(streakSettings, (val) => {
+  localStorage.setItem(STREAK_SETTINGS_KEY, JSON.stringify(val))
+}, { deep: true })
+
+// Streak is alive if no non-excluded day between lastCompletedDate and today was missed
+const streakCount = computed(() => {
+  const { count, lastCompletedDate } = streakData.value
+  if (!lastCompletedDate) return 0
+  if (hasActiveDayBetween(lastCompletedDate, today.value, streakSettings.value)) return 0
+  return count
+})
+
+export function useStreak() {
+  function recordCompletion() {
+    const now = todayString()
+    const settings = streakSettings.value
+
+    if (streakData.value.lastCompletedDate === now) return
+    if (isExcluded(now, settings)) return
+
+    const { count, lastCompletedDate } = streakData.value
+    const streakAlive = lastCompletedDate && !hasActiveDayBetween(lastCompletedDate, now, settings)
+    const newCount = streakAlive ? count + 1 : 1
+
+    streakData.value = { count: newCount, lastCompletedDate: now }
+    localStorage.setItem(STREAK_KEY, JSON.stringify(streakData.value))
+  }
+
+  return { streakCount, streakSettings, recordCompletion }
+}

--- a/src/composables/useTasks.js
+++ b/src/composables/useTasks.js
@@ -1,5 +1,8 @@
 import { ref, watch } from 'vue'
 import { ENERGY_LEVELS, COLUMNS } from '../constants/energy.js'
+import { useStreak } from './useStreak.js'
+
+const { recordCompletion } = useStreak()
 
 const STORAGE_KEY = 'untangle-tasks'
 const ENERGY_KEY = 'untangle-energy'
@@ -74,7 +77,10 @@ export function useTasks() {
 
   function completeTask(id) {
     const task = tasks.value.find(t => t.id === id)
-    if (task) task.completedAt = Date.now()
+    if (task) {
+      task.completedAt = Date.now()
+      recordCompletion()
+    }
   }
 
   function updateTask(id, changes) {

--- a/tests/e2e/streak.spec.js
+++ b/tests/e2e/streak.spec.js
@@ -1,0 +1,209 @@
+import { test, expect } from '@playwright/test'
+import { addTask, taskCard } from './helpers.js'
+
+/** Calculate a local date string in the browser (offsetDays from today). */
+async function localDate(page, offsetDays = 0) {
+  return page.evaluate((offset) => {
+    const d = new Date()
+    d.setDate(d.getDate() + offset)
+    const y = d.getFullYear()
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const day = String(d.getDate()).padStart(2, '0')
+    return `${y}-${m}-${day}`
+  }, offsetDays)
+}
+
+async function openSettings(page) {
+  await page.getByRole('button', { name: /open settings/i }).click()
+}
+
+test.describe('streak', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.evaluate(() => localStorage.clear())
+    await page.reload()
+  })
+
+  test.describe('streak display', () => {
+    test('shows a streak display in the header', async ({ page }) => {
+      await expect(page.locator('.streak-display')).toBeVisible()
+    })
+
+    test('shows "0 days" when no tasks have been completed', async ({ page }) => {
+      await expect(page.locator('.streak-text')).toHaveText('0 days')
+    })
+
+    test('does not have active styling when streak is 0', async ({ page }) => {
+      await expect(page.locator('.streak-display')).not.toHaveClass(/streak-active/)
+    })
+
+    test('shows "1 day" after completing a task today', async ({ page }) => {
+      await addTask(page, 'now', 'First task')
+      const card = taskCard(page, 'now', 'First task')
+      await card.hover()
+      await card.locator('.complete-btn').click()
+      await expect(page.locator('.streak-text')).toHaveText('1 day')
+    })
+
+    test('has active styling after completing a task', async ({ page }) => {
+      await addTask(page, 'now', 'Active task')
+      const card = taskCard(page, 'now', 'Active task')
+      await card.hover()
+      await card.locator('.complete-btn').click()
+      await expect(page.locator('.streak-display')).toHaveClass(/streak-active/)
+    })
+
+    test('completing a second task on the same day does not increment the streak', async ({ page }) => {
+      await addTask(page, 'now', 'Task one')
+      await addTask(page, 'now', 'Task two')
+
+      const card1 = taskCard(page, 'now', 'Task one')
+      await card1.hover()
+      await card1.locator('.complete-btn').click()
+      await expect(page.locator('.streak-text')).toHaveText('1 day')
+
+      const card2 = taskCard(page, 'now', 'Task two')
+      await card2.hover()
+      await card2.locator('.complete-btn').click()
+      await expect(page.locator('.streak-text')).toHaveText('1 day')
+    })
+
+    test('shows stored streak count when the streak was active yesterday', async ({ page }) => {
+      const yesterday = await localDate(page, -1)
+      await page.evaluate((date) => {
+        localStorage.setItem('untangle-streak', JSON.stringify({ count: 4, lastCompletedDate: date }))
+      }, yesterday)
+      await page.reload()
+      await expect(page.locator('.streak-text')).toHaveText('4 days')
+      await expect(page.locator('.streak-display')).toHaveClass(/streak-active/)
+    })
+
+    test('shows 0 when a day was missed', async ({ page }) => {
+      const twoDaysAgo = await localDate(page, -2)
+      await page.evaluate((date) => {
+        localStorage.setItem('untangle-streak', JSON.stringify({ count: 7, lastCompletedDate: date }))
+      }, twoDaysAgo)
+      await page.reload()
+      await expect(page.locator('.streak-text')).toHaveText('0 days')
+      await expect(page.locator('.streak-display')).not.toHaveClass(/streak-active/)
+    })
+
+    test('increments onto an existing streak when completing today', async ({ page }) => {
+      const yesterday = await localDate(page, -1)
+      await page.evaluate((date) => {
+        localStorage.setItem('untangle-streak', JSON.stringify({ count: 3, lastCompletedDate: date }))
+      }, yesterday)
+      await page.reload()
+
+      await addTask(page, 'now', 'Keep it going')
+      const card = taskCard(page, 'now', 'Keep it going')
+      await card.hover()
+      await card.locator('.complete-btn').click()
+      await expect(page.locator('.streak-text')).toHaveText('4 days')
+    })
+  })
+
+  test.describe('streak persistence', () => {
+    test('streak count survives a page reload', async ({ page }) => {
+      await addTask(page, 'now', 'Persist me')
+      const card = taskCard(page, 'now', 'Persist me')
+      await card.hover()
+      await card.locator('.complete-btn').click()
+      await expect(page.locator('.streak-text')).toHaveText('1 day')
+      await page.reload()
+      await expect(page.locator('.streak-text')).toHaveText('1 day')
+    })
+  })
+
+  test.describe('streak settings — display', () => {
+    test('settings panel shows a Streak section', async ({ page }) => {
+      await openSettings(page)
+      await expect(page.locator('.section-title')).toHaveText('Streak')
+    })
+
+    test('shows the Exclude weekends toggle', async ({ page }) => {
+      await openSettings(page)
+      await expect(page.locator('.toggle-name').filter({ hasText: 'Exclude weekends' })).toBeVisible()
+    })
+
+    test('shows the Exclude UK bank holidays toggle', async ({ page }) => {
+      await openSettings(page)
+      await expect(page.locator('.toggle-name').filter({ hasText: 'Exclude UK bank holidays' })).toBeVisible()
+    })
+
+    test('shows the Streak freeze toggle', async ({ page }) => {
+      await openSettings(page)
+      await expect(page.locator('.toggle-name').filter({ hasText: 'Streak freeze' })).toBeVisible()
+    })
+
+    test('the Streak section appears below the About nav item', async ({ page }) => {
+      await openSettings(page)
+      const aboutBtn = page.locator('.settings-nav-item')
+      const streakSection = page.locator('.settings-section')
+      const aboutBox = await aboutBtn.boundingBox()
+      const sectionBox = await streakSection.boundingBox()
+      expect(sectionBox.y).toBeGreaterThan(aboutBox.y)
+    })
+  })
+
+  test.describe('streak settings — streak freeze', () => {
+    test('the freeze date picker is hidden when streak freeze is off', async ({ page }) => {
+      await openSettings(page)
+      await expect(page.locator('.freeze-date-row')).not.toBeVisible()
+    })
+
+    test('enabling streak freeze reveals the date picker', async ({ page }) => {
+      await openSettings(page)
+      await page.locator('input[aria-label="Enable streak freeze"]').check()
+      await expect(page.locator('.freeze-date-row')).toBeVisible()
+    })
+
+    test('the freeze date picker defaults to today when first enabled', async ({ page }) => {
+      const today = await localDate(page)
+      await openSettings(page)
+      await page.locator('input[aria-label="Enable streak freeze"]').check()
+      await expect(page.locator('.freeze-date-input')).toHaveValue(today)
+    })
+
+    test('disabling streak freeze hides the date picker again', async ({ page }) => {
+      await openSettings(page)
+      const freezeToggle = page.locator('input[aria-label="Enable streak freeze"]')
+      await freezeToggle.check()
+      await expect(page.locator('.freeze-date-row')).toBeVisible()
+      await freezeToggle.uncheck()
+      await expect(page.locator('.freeze-date-row')).not.toBeVisible()
+    })
+  })
+
+  test.describe('streak settings — persistence', () => {
+    test('Exclude weekends setting survives a page reload', async ({ page }) => {
+      await openSettings(page)
+      await page.locator('input[aria-label="Exclude weekends from streak"]').check()
+      await page.locator('.settings-close').click()
+      await page.reload()
+      await openSettings(page)
+      await expect(page.locator('input[aria-label="Exclude weekends from streak"]')).toBeChecked()
+    })
+
+    test('Exclude UK bank holidays setting survives a page reload', async ({ page }) => {
+      await openSettings(page)
+      await page.locator('input[aria-label="Exclude UK bank holidays from streak"]').check()
+      await page.locator('.settings-close').click()
+      await page.reload()
+      await openSettings(page)
+      await expect(page.locator('input[aria-label="Exclude UK bank holidays from streak"]')).toBeChecked()
+    })
+
+    test('Streak freeze date survives a page reload', async ({ page }) => {
+      await openSettings(page)
+      await page.locator('input[aria-label="Enable streak freeze"]').check()
+      const freezeInput = page.locator('.freeze-date-input')
+      await freezeInput.fill('2025-12-31')
+      await page.locator('.settings-close').click()
+      await page.reload()
+      await openSettings(page)
+      await expect(page.locator('input[aria-label="Enable streak freeze"]')).toBeChecked()
+      await expect(page.locator('.freeze-date-input')).toHaveValue('2025-12-31')
+    })
+  })
+})

--- a/tests/unit/streak/components.test.js
+++ b/tests/unit/streak/components.test.js
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, shallowMount } from '@vue/test-utils'
+import { ref, nextTick } from 'vue'
+
+// eslint-disable-next-line no-var
+var mockStreakCount
+// eslint-disable-next-line no-var
+var mockStreakSettings
+
+vi.mock('../../../src/composables/useStreak.js', () => {
+  mockStreakCount = ref(0)
+  mockStreakSettings = ref({ excludeWeekends: false, excludeBankHolidays: false, freezeUntil: null })
+  return {
+    useStreak: () => ({
+      streakCount: mockStreakCount,
+      streakSettings: mockStreakSettings,
+      recordCompletion: vi.fn(),
+    }),
+    todayString: () => '2025-06-02',
+  }
+})
+
+vi.mock('../../../src/composables/useEncouragement.js', () => ({
+  useEncouragement: () => ({
+    showEncouragement: vi.fn(),
+    dismissEncouragement: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../src/composables/useToughLove.js', () => ({
+  useToughLove: () => ({
+    showToughLove: vi.fn(),
+    dismissToughLove: vi.fn(),
+    toughLove: ref(null),
+  }),
+}))
+
+import App from '../../../src/App.vue'
+import SettingsPanel from '../../../src/components/SettingsPanel.vue'
+
+describe('streak — components', () => {
+  beforeEach(() => {
+    mockStreakCount.value = 0
+    mockStreakSettings.value = { excludeWeekends: false, excludeBankHolidays: false, freezeUntil: null }
+  })
+
+  describe('App.vue — streak display', () => {
+    it('renders the streak display element', () => {
+      const wrapper = shallowMount(App)
+      expect(wrapper.find('.streak-display').exists()).toBe(true)
+    })
+
+    it('shows "0 days" when streak is 0', () => {
+      const wrapper = shallowMount(App)
+      expect(wrapper.find('.streak-text').text()).toBe('0 days')
+    })
+
+    it('does not have streak-active class when streak is 0', () => {
+      const wrapper = shallowMount(App)
+      expect(wrapper.find('.streak-display').classes()).not.toContain('streak-active')
+    })
+
+    it('has streak-active class when streak is greater than 0', async () => {
+      mockStreakCount.value = 3
+      const wrapper = shallowMount(App)
+      await nextTick()
+      expect(wrapper.find('.streak-display').classes()).toContain('streak-active')
+    })
+
+    it('shows "1 day" (singular) when streak is 1', async () => {
+      mockStreakCount.value = 1
+      const wrapper = shallowMount(App)
+      await nextTick()
+      expect(wrapper.find('.streak-text').text()).toBe('1 day')
+    })
+
+    it('shows "N days" (plural) when streak is greater than 1', async () => {
+      mockStreakCount.value = 7
+      const wrapper = shallowMount(App)
+      await nextTick()
+      expect(wrapper.find('.streak-text').text()).toBe('7 days')
+    })
+
+    it('shows the flame icon', () => {
+      const wrapper = shallowMount(App)
+      expect(wrapper.find('.streak-icon').text()).toBe('🔥')
+    })
+
+    it('updates the display when streakCount changes reactively', async () => {
+      const wrapper = shallowMount(App)
+      expect(wrapper.find('.streak-text').text()).toBe('0 days')
+
+      mockStreakCount.value = 4
+      await nextTick()
+
+      expect(wrapper.find('.streak-text').text()).toBe('4 days')
+      expect(wrapper.find('.streak-display').classes()).toContain('streak-active')
+    })
+  })
+
+  describe('SettingsPanel.vue — streak section', () => {
+    it('shows a Streak settings section', () => {
+      const wrapper = mount(SettingsPanel)
+      expect(wrapper.find('.settings-section').exists()).toBe(true)
+      expect(wrapper.find('.section-title').text()).toBe('Streak')
+    })
+
+    it('shows three toggle rows', () => {
+      const wrapper = mount(SettingsPanel)
+      expect(wrapper.findAll('.toggle-row')).toHaveLength(3)
+    })
+
+    it('shows the Exclude weekends toggle', () => {
+      const wrapper = mount(SettingsPanel)
+      const names = wrapper.findAll('.toggle-name').map(n => n.text())
+      expect(names).toContain('Exclude weekends')
+    })
+
+    it('shows the Exclude UK bank holidays toggle', () => {
+      const wrapper = mount(SettingsPanel)
+      const names = wrapper.findAll('.toggle-name').map(n => n.text())
+      expect(names).toContain('Exclude UK bank holidays')
+    })
+
+    it('shows the Streak freeze toggle', () => {
+      const wrapper = mount(SettingsPanel)
+      const names = wrapper.findAll('.toggle-name').map(n => n.text())
+      expect(names).toContain('Streak freeze')
+    })
+
+    it('the Streak section appears after the About nav item', () => {
+      const wrapper = mount(SettingsPanel)
+      const nav = wrapper.find('.settings-nav')
+      const section = wrapper.find('.settings-section')
+      const position = nav.element.compareDocumentPosition(section.element)
+      expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+
+    it('toggling Exclude weekends updates the setting', async () => {
+      const wrapper = mount(SettingsPanel)
+      const checkboxes = wrapper.findAll('input[type="checkbox"]')
+      await checkboxes[0].setValue(true)
+      expect(mockStreakSettings.value.excludeWeekends).toBe(true)
+    })
+
+    it('toggling Exclude UK bank holidays updates the setting', async () => {
+      const wrapper = mount(SettingsPanel)
+      const checkboxes = wrapper.findAll('input[type="checkbox"]')
+      await checkboxes[1].setValue(true)
+      expect(mockStreakSettings.value.excludeBankHolidays).toBe(true)
+    })
+
+    it('hides the date picker when streak freeze is not enabled', () => {
+      const wrapper = mount(SettingsPanel)
+      expect(wrapper.find('.freeze-date-row').exists()).toBe(false)
+    })
+
+    it('shows the date picker when streak freeze is enabled', async () => {
+      const wrapper = mount(SettingsPanel)
+      const checkboxes = wrapper.findAll('input[type="checkbox"]')
+      await checkboxes[2].setValue(true)
+      await nextTick()
+      expect(wrapper.find('.freeze-date-row').exists()).toBe(true)
+    })
+
+    it('sets freezeUntil to today when freeze is first enabled', async () => {
+      const wrapper = mount(SettingsPanel)
+      const checkboxes = wrapper.findAll('input[type="checkbox"]')
+      await checkboxes[2].setValue(true)
+      expect(mockStreakSettings.value.freezeUntil).toBe('2025-06-02')
+    })
+
+    it('clears freezeUntil when freeze is disabled', async () => {
+      mockStreakSettings.value.freezeUntil = '2025-06-05'
+      const wrapper = mount(SettingsPanel)
+      const checkboxes = wrapper.findAll('input[type="checkbox"]')
+      await checkboxes[2].setValue(false)
+      expect(mockStreakSettings.value.freezeUntil).toBeNull()
+    })
+
+    it('reflects existing setting values on render', () => {
+      mockStreakSettings.value.excludeWeekends = true
+      mockStreakSettings.value.excludeBankHolidays = true
+      const wrapper = mount(SettingsPanel)
+      const checkboxes = wrapper.findAll('input[type="checkbox"]')
+      expect(checkboxes[0].element.checked).toBe(true)
+      expect(checkboxes[1].element.checked).toBe(true)
+      expect(checkboxes[2].element.checked).toBe(false)
+    })
+  })
+})

--- a/tests/unit/streak/composable.test.js
+++ b/tests/unit/streak/composable.test.js
@@ -1,0 +1,364 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+const MON  = '2025-06-02'
+const TUE  = '2025-06-03'
+const WED  = '2025-06-04'
+const FRI  = '2025-06-06'
+const SAT  = '2025-06-07'
+const MON2 = '2025-06-09'
+const TUE2 = '2025-06-10'
+
+// Christmas 2024 bank holiday block: Wed Dec 25 + Thu Dec 26 (no weekends in gap)
+const TUE_BEFORE_XMAS  = '2024-12-24'
+const XMAS_DAY         = '2024-12-25' // bank holiday (Wednesday)
+const BOXING_DAY       = '2024-12-26' // bank holiday (Thursday)
+const FRI_AFTER_XMAS   = '2024-12-27'
+const SAT_AFTER_XMAS   = '2024-12-28'
+
+describe('useStreak — composable', () => {
+  let useStreak, todayString
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(`${MON}T09:00:00`))
+    vi.resetModules()
+    ;({ useStreak, todayString } = await import('../../../src/composables/useStreak.js'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  async function advanceTo(dateStr) {
+    vi.resetModules()
+    vi.setSystemTime(new Date(`${dateStr}T09:00:00`))
+    ;({ useStreak } = await import('../../../src/composables/useStreak.js'))
+  }
+
+  describe('initial state', () => {
+    it('streakCount starts at 0', () => {
+      const { streakCount } = useStreak()
+      expect(streakCount.value).toBe(0)
+    })
+
+    it('streakSettings defaults to all exclusions off', () => {
+      const { streakSettings } = useStreak()
+      expect(streakSettings.value.excludeWeekends).toBe(false)
+      expect(streakSettings.value.excludeBankHolidays).toBe(false)
+      expect(streakSettings.value.freezeUntil).toBeNull()
+    })
+  })
+
+  describe('todayString', () => {
+    it('returns the current local date as YYYY-MM-DD', () => {
+      expect(todayString()).toBe(MON)
+    })
+  })
+
+  describe('recordCompletion', () => {
+    it('sets streakCount to 1 on first completion', () => {
+      const { streakCount, recordCompletion } = useStreak()
+      recordCompletion()
+      expect(streakCount.value).toBe(1)
+    })
+
+    it('is a no-op when called twice on the same day', () => {
+      const { streakCount, recordCompletion } = useStreak()
+      recordCompletion()
+      recordCompletion()
+      expect(streakCount.value).toBe(1)
+    })
+
+    it('increments to 2 when completed on the next consecutive day', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Monday
+
+      await advanceTo(TUE)
+      const { streakCount, recordCompletion: rec } = useStreak()
+      rec()
+      expect(streakCount.value).toBe(2)
+    })
+
+    it('resets to 1 when a day was skipped', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Monday
+
+      await advanceTo(WED) // skipped Tuesday
+      const { streakCount, recordCompletion: rec } = useStreak()
+      rec()
+      expect(streakCount.value).toBe(1)
+    })
+  })
+
+  describe('streakCount display', () => {
+    it('shows streak as alive when last completed today', () => {
+      const { streakCount, recordCompletion } = useStreak()
+      recordCompletion()
+      expect(streakCount.value).toBe(1)
+    })
+
+    it('shows streak as alive when last completed yesterday', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Monday
+
+      await advanceTo(TUE) // no completion today
+      const { streakCount } = useStreak()
+      expect(streakCount.value).toBe(1)
+    })
+
+    it('shows 0 when a day was missed with no new completion', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Monday
+
+      await advanceTo(WED) // Tuesday missed
+      const { streakCount } = useStreak()
+      expect(streakCount.value).toBe(0)
+    })
+  })
+
+  describe('weekend exclusion', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+      vi.setSystemTime(new Date(`${FRI}T09:00:00`))
+      ;({ useStreak } = await import('../../../src/composables/useStreak.js'))
+    })
+
+    it('completing on Saturday is a no-op when weekends are excluded', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Friday
+
+      await advanceTo(SAT)
+      const { streakSettings, recordCompletion: rec, streakCount } = useStreak()
+      streakSettings.value.excludeWeekends = true
+      rec()
+      expect(streakCount.value).toBe(1) // still 1, Saturday completion didn't increment
+    })
+
+    it('streak survives over a weekend without any completion', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Friday
+
+      await advanceTo(MON2)
+      const { streakSettings, streakCount } = useStreak()
+      streakSettings.value.excludeWeekends = true
+      expect(streakCount.value).toBe(1) // alive — Sat/Sun were excluded
+    })
+
+    it('increments on Monday after Friday when weekends are excluded', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Friday
+
+      await advanceTo(MON2)
+      const { streakSettings, recordCompletion: rec, streakCount } = useStreak()
+      streakSettings.value.excludeWeekends = true
+      rec()
+      expect(streakCount.value).toBe(2)
+    })
+
+    it('resets if the first active day after the excluded weekend is also missed', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Friday
+
+      await advanceTo(TUE2) // skipped Monday (first required day)
+      const { streakSettings, streakCount } = useStreak()
+      streakSettings.value.excludeWeekends = true
+      expect(streakCount.value).toBe(0)
+    })
+  })
+
+  describe('bank holiday exclusion', () => {
+    // Uses Christmas 2024: Wed Dec 25 + Thu Dec 26 are bank holidays with no weekends in gap
+    beforeEach(async () => {
+      vi.resetModules()
+      vi.setSystemTime(new Date(`${TUE_BEFORE_XMAS}T09:00:00`))
+      ;({ useStreak } = await import('../../../src/composables/useStreak.js'))
+    })
+
+    it('completing on Christmas Day is a no-op when bank holidays are excluded', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Tuesday Dec 24
+
+      await advanceTo(XMAS_DAY)
+      const { streakSettings, recordCompletion: rec, streakCount } = useStreak()
+      streakSettings.value.excludeBankHolidays = true
+      rec()
+      expect(streakCount.value).toBe(1) // still 1
+    })
+
+    it('streak survives over Christmas + Boxing Day without any completion', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Tuesday Dec 24
+
+      await advanceTo(FRI_AFTER_XMAS)
+      const { streakSettings, streakCount } = useStreak()
+      streakSettings.value.excludeBankHolidays = true
+      expect(streakCount.value).toBe(1) // alive — Dec 25 + Dec 26 excluded
+    })
+
+    it('increments on first active day after the bank holiday block', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Tuesday Dec 24
+
+      await advanceTo(FRI_AFTER_XMAS)
+      const { streakSettings, recordCompletion: rec, streakCount } = useStreak()
+      streakSettings.value.excludeBankHolidays = true
+      rec()
+      expect(streakCount.value).toBe(2)
+    })
+
+    it('resets if the first active day after the bank holiday block is missed', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Tuesday Dec 24
+
+      await advanceTo(SAT_AFTER_XMAS) // Friday was first required day, missed it
+      const { streakSettings, streakCount } = useStreak()
+      streakSettings.value.excludeBankHolidays = true
+      expect(streakCount.value).toBe(0)
+    })
+  })
+
+  describe('streak freeze', () => {
+    it('completing on a frozen day is a no-op', () => {
+      const { streakSettings, recordCompletion, streakCount } = useStreak()
+      streakSettings.value.freezeUntil = FRI // freeze through Friday
+      recordCompletion() // Monday, within freeze
+      expect(streakCount.value).toBe(0)
+    })
+
+    it('streak survives while frozen — the gap is covered by the freeze', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Monday
+
+      await advanceTo(FRI) // Tue/Wed/Thu were frozen
+      const { streakSettings, streakCount } = useStreak()
+      streakSettings.value.freezeUntil = '2025-06-05' // freeze through Thursday
+      expect(streakCount.value).toBe(1)
+    })
+
+    it('increments on the first active day after the freeze ends', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Monday
+
+      await advanceTo(FRI)
+      const { streakSettings, recordCompletion: rec, streakCount } = useStreak()
+      streakSettings.value.freezeUntil = '2025-06-05'
+      rec()
+      expect(streakCount.value).toBe(2)
+    })
+
+    it('resets if the first active day after the freeze is missed', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Monday
+
+      await advanceTo(SAT) // Friday was first active day after Thu freeze, missed it
+      const { streakSettings, streakCount } = useStreak()
+      streakSettings.value.freezeUntil = '2025-06-05'
+      expect(streakCount.value).toBe(0)
+    })
+  })
+
+  describe('all three exclusions combined', () => {
+    it('all three settings can be active simultaneously without error', () => {
+      const { streakSettings } = useStreak()
+      streakSettings.value.excludeWeekends = true
+      streakSettings.value.excludeBankHolidays = true
+      streakSettings.value.freezeUntil = TUE
+      expect(streakSettings.value.excludeWeekends).toBe(true)
+      expect(streakSettings.value.excludeBankHolidays).toBe(true)
+      expect(streakSettings.value.freezeUntil).toBe(TUE)
+    })
+
+    it('a day excluded by any rule is skipped for increment and gap detection', async () => {
+      // Start on Friday, enable weekends + freeze covering Mon
+      vi.resetModules()
+      vi.setSystemTime(new Date(`${FRI}T09:00:00`))
+      ;({ useStreak } = await import('../../../src/composables/useStreak.js'))
+
+      const { recordCompletion } = useStreak()
+      recordCompletion() // Friday
+
+      // Check on Tuesday: Sat/Sun excluded by weekends, Mon excluded by freeze
+      await advanceTo(TUE2)
+      const { streakSettings, streakCount } = useStreak()
+      streakSettings.value.excludeWeekends = true
+      streakSettings.value.freezeUntil = MON2 // freeze through Monday
+      expect(streakCount.value).toBe(1) // streak alive — all days in gap were excluded
+    })
+
+    it('completing on a day excluded by any one rule is always a no-op', async () => {
+      // Saturday excluded by weekends only
+      vi.resetModules()
+      vi.setSystemTime(new Date(`${SAT}T09:00:00`))
+      ;({ useStreak } = await import('../../../src/composables/useStreak.js'))
+
+      const { streakSettings, recordCompletion, streakCount } = useStreak()
+      streakSettings.value.excludeWeekends = true
+      recordCompletion()
+      expect(streakCount.value).toBe(0)
+    })
+  })
+
+  describe('settings persistence', () => {
+    it('streak data persists across module reloads', async () => {
+      const { recordCompletion } = useStreak()
+      recordCompletion()
+
+      await advanceTo(MON)
+      const { streakCount } = useStreak()
+      expect(streakCount.value).toBe(1)
+    })
+
+    it('streak settings persist across module reloads', async () => {
+      const { streakSettings } = useStreak()
+      streakSettings.value.excludeWeekends = true
+      await nextTick() // flush the deep watcher
+
+      await advanceTo(MON)
+      const { streakSettings: s2 } = useStreak()
+      expect(s2.value.excludeWeekends).toBe(true)
+    })
+
+    it('freeze date persists across module reloads', async () => {
+      const { streakSettings } = useStreak()
+      streakSettings.value.freezeUntil = FRI
+      await nextTick()
+
+      await advanceTo(MON)
+      const { streakSettings: s2 } = useStreak()
+      expect(s2.value.freezeUntil).toBe(FRI)
+    })
+  })
+
+  describe('midnight rollover', () => {
+    it('streakCount recomputes when today rolls to the next day', () => {
+      const { streakCount, recordCompletion } = useStreak()
+      recordCompletion() // Monday
+      expect(streakCount.value).toBe(1)
+
+      // Advance to just after Tuesday midnight
+      const now = new Date(`${MON}T09:00:00`)
+      const tueMidnight = new Date(`${TUE}T00:00:00`)
+      vi.setSystemTime(tueMidnight.getTime() + 1000)
+      vi.advanceTimersByTime(tueMidnight.getTime() - now.getTime() + 1000)
+
+      // Tuesday: no gap between Mon and Tue, streak still alive
+      expect(streakCount.value).toBe(1)
+    })
+
+    it('streak shows 0 after two midnights pass without a new completion', () => {
+      const { streakCount, recordCompletion } = useStreak()
+      recordCompletion() // Monday
+      expect(streakCount.value).toBe(1)
+
+      // Advance past two midnights to Wednesday
+      const now = new Date(`${MON}T09:00:00`)
+      const wedMorning = new Date(`${WED}T01:00:00`)
+      vi.setSystemTime(wedMorning)
+      vi.advanceTimersByTime(wedMorning.getTime() - now.getTime())
+
+      // Wednesday: Tuesday was a gap, streak resets
+      expect(streakCount.value).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a streak counter to the header showing how many consecutive days the user has completed at least one task — increments on the first completion of the day, resets to 0 if a full active day passes with no completion
- Adds a **Streak** section to Settings with three independent exclusion rules: exclude weekends, exclude UK bank holidays (England & Wales, 2024–2028), and streak freeze until a chosen date — excluded days are fully transparent (no completion required, completions don't increment)
- Streak count recomputes automatically at local midnight via a reactive `today` ref updated by a self-rescheduling `setTimeout`

## What changed

| File | Change |
|---|---|
| `src/composables/useStreak.js` | New singleton composable — streak data, settings, exclusion logic, `recordCompletion()` |
| `src/composables/useTasks.js` | Calls `recordCompletion()` inside `completeTask()` |
| `src/App.vue` | Streak display (🔥 + day count) in header; `streak-active` class when count > 0 |
| `src/components/SettingsPanel.vue` | Streak settings section with three toggles and conditional freeze date picker |
| `tests/unit/streak/composable.test.js` | 30 unit tests — streak logic, all three exclusion types, combined exclusions, persistence, midnight rollover |
| `tests/unit/streak/components.test.js` | 21 unit tests — App.vue streak display rendering, SettingsPanel settings section |
| `tests/e2e/streak.spec.js` | 22 E2E tests — display, increment on completion, same-day no-op, stored state, persistence, settings UI, settings persistence |
| `README.md` / `CLAUDE.md` | Documented the new feature, composable, and updated test counts |

## Implementation notes

The increment condition was simplified during test authoring: rather than using a `prevActiveDay` anchor (which broke when `freezeUntil` also covered the last completion date), `recordCompletion` now uses `hasActiveDayBetween(lastCompletedDate, now, settings)` directly — the same check `streakCount` uses for display. This is both simpler and correct for all three exclusion types.

## Test plan

- [x] Unit tests: `npm test` — 231 tests pass
- [x] E2E tests: `npm run test:e2e` — 106 tests pass
- [x] Production build: `npm run build`