### PR TITLE
Add qa-review skill with worktree and e2e support

### DIFF
--- a/.claude/skills/qa-review.md
+++ b/.claude/skills/qa-review.md
@@ -1,0 +1,114 @@
+Review and fix all code changes on the current branch, ensure tests and docs are in place, and issue a QA approval marker so a pull request can be created.
+
+## Steps
+
+### 1. Identify what changed
+
+```
+git diff main...HEAD --name-only
+git diff main...HEAD
+```
+
+List every changed file. Group them by type: source files, tests, docs, config.
+
+Also determine the project root for running npm commands. In a worktree, `node_modules` lives in the main repo, not the worktree checkout:
+
+```
+git_dir=$(git rev-parse --git-dir)
+if [ -f "${git_dir}/commondir" ]; then
+  # Running in a worktree — resolve main repo root via commondir
+  common=$(cat "${git_dir}/commondir")
+  project_root=$(cd "${git_dir}/${common}/.." && pwd)
+else
+  project_root=$(git rev-parse --show-toplevel)
+fi
+```
+
+Use `$project_root` as the working directory for all `npm` commands in the steps below.
+
+### 2. Code quality review
+
+For every changed source file, look for:
+
+- **Contradictory logic** — conditions that can never be true, branches that undo each other, state that is set and then immediately overwritten
+- **Vague logic** — magic numbers or strings with no named constant, boolean arguments to functions where the meaning is unclear at the call site, variable names that don't reflect what they hold
+- **Inefficiency** — unnecessary reactive re-computation in Vue composables, repeated identical lookups inside loops, derived state that is recomputed instead of cached
+- **Flakiness** — code that depends on timing, ordering of async operations, or global state without proper reset
+- **Maintainability** — deeply nested conditionals that could be early-returned, large functions doing multiple unrelated things, dead code (unused imports, unreachable branches, commented-out blocks)
+
+Fix every issue you find. Prefer minimal targeted edits — don't refactor surrounding code that isn't part of the change.
+
+### 3. Test coverage check
+
+Determine whether the changed code needs new or updated tests.
+
+**Unit tests are needed when:**
+- A composable has new or changed logic (filtering, state transitions, computed values, side effects)
+- A component has new conditional rendering, new props, or new emits
+
+**E2E tests are needed when:**
+- A user-visible feature is added or changed
+- A new interaction flow exists (drag, edit, delete, toggle)
+- A bug fix addresses something a user would notice
+
+**Test structure for this project:**
+- Unit tests live in `tests/unit/<feature>/` as two files: `composable.test.js` (uses `vi.resetModules()`) and `components.test.js` (uses `vi.mock(...)`)
+- E2E tests live in `tests/e2e/<feature>.spec.js` and use helpers from `tests/e2e/helpers.js`
+- See existing tests for naming, structure, and setup patterns — match them exactly
+
+If tests are needed and don't exist, write them now. If existing tests cover the change, verify they still pass. Run from `$project_root`:
+```
+cd $project_root && npm test -- --run          # unit tests
+cd $project_root && npm run test:e2e           # e2e tests
+```
+
+### 4. Documentation review
+
+Check every `.md` file that was changed in the branch, plus `README.md` and `CLAUDE.md` regardless of whether they were touched.
+
+For each doc, ask:
+- Does it describe something that now works differently?
+- Is there a new feature, command, file, or architectural concept that should be mentioned?
+- Is there anything that's now wrong or misleading?
+
+Update docs where the answer is yes. Don't add docs for internal implementation details — only user-facing or contributor-facing information.
+
+### 5. Final verification
+
+Run from `$project_root`:
+```
+cd $project_root && npm test -- --run
+```
+
+If you created or modified any E2E tests, also run:
+```
+cd $project_root && npm run test:e2e
+```
+
+If any test fails, fix it before continuing.
+
+### 6. Write the approval marker
+
+If all steps above are clean (issues fixed, tests passing, docs current), write the QA approval marker:
+
+```
+git rev-parse --git-dir   # get the git directory
+```
+
+Create the directory `<git-dir>/claude-qa/` if it doesn't exist, then write a file named `<safe-branch>.approved` where `<safe-branch>` is the branch name with `/` and `\` replaced by `_`.
+
+The file should contain only the current commit hash (from `git rev-parse HEAD`), with no trailing newline or whitespace.
+
+Example for branch `feature/my-task` at commit `abc123`:
+- File: `.git/claude-qa/feature_my-task.approved`
+- Content: `abc123def456...` (full 40-char hash)
+
+### 7. Report
+
+End with a summary:
+- Issues found and fixed (or "none found")
+- Tests created (or "existing tests sufficient" / "no tests needed")
+- Docs updated (or "no updates needed")
+- QA result: APPROVED or BLOCKED (with reason if blocked)
+
+If blocked, explain exactly what needs to be resolved before the PR can be created.


### PR DESCRIPTION
## What changed

Adds `.claude/skills/qa-review.md` to the repo so the skill is versioned alongside the codebase it governs. The skill also received two improvements made this session:

- **Worktree support** — `npm` commands now detect when running in a git worktree (via the `commondir` file) and resolve the main repo root where `node_modules` lives, so `npm test` and `npm run test:e2e` work correctly from a worktree checkout.
- **E2E test verification** — step 5 (final verification) now runs `npm run test:e2e` when e2e tests were written or modified, not just the unit suite.

## Reviewer notes

The skill file at `.claude/skills/qa-review.md` is loaded by Claude Code as a project-level skill, complementing (or replacing) the user-level copy at `~/.claude/skills/qa-review.md`. The content is identical to the user-level file so either location works.