### PR TITLE
Add automated bug tracking via GitHub Issues

### DIFF
--- a/.claude/skills/qa-review.md
+++ b/.claude/skills/qa-review.md
@@ -36,7 +36,27 @@ For every changed source file, look for:
 - **Flakiness** — code that depends on timing, ordering of async operations, or global state without proper reset
 - **Maintainability** — deeply nested conditionals that could be early-returned, large functions doing multiple unrelated things, dead code (unused imports, unreachable branches, commented-out blocks)
 
+For each bug found, **before fixing it**, create a GitHub issue:
+
+```
+node scripts/bug-tracker.mjs create \
+  --title "Bug: <concise one-line description>" \
+  --body "<what the bug is, which file and line, how it manifests>" \
+  --source "qa-review"
+```
+
+The output will be `CREATED:N` (new issue) or `EXISTS:N` (already tracked). Note the issue number.
+
 Fix every issue you find. Prefer minimal targeted edits — don't refactor surrounding code that isn't part of the change.
+
+After fixing each bug, close its issue with the root cause and fix details:
+
+```
+node scripts/bug-tracker.mjs close \
+  --number <N> \
+  --cause "<root cause — why the bug existed>" \
+  --fix "<what was changed to fix it>"
+```
 
 ### 3. Test coverage check
 
@@ -62,6 +82,24 @@ cd $project_root && npm test -- --run          # unit tests
 cd $project_root && npm run test:e2e           # e2e tests
 ```
 
+If a test fails because of a real bug in the source code (not a test setup issue), create a GitHub issue for it before fixing:
+
+```
+node scripts/bug-tracker.mjs create \
+  --title "Bug: <failing test name — what it expected vs what happened>" \
+  --body "<test file and line, failure message, what the test exercises>" \
+  --source "unit-test"   # or "e2e-test"
+```
+
+After fixing the source bug, close the issue:
+
+```
+node scripts/bug-tracker.mjs close \
+  --number <N> \
+  --cause "<root cause>" \
+  --fix "<what was changed>"
+```
+
 ### 4. Documentation review
 
 Check every `.md` file that was changed in the branch, plus `README.md` and `CLAUDE.md` regardless of whether they were touched.
@@ -85,7 +123,7 @@ If you created or modified any E2E tests, also run:
 cd $project_root && npm run test:e2e
 ```
 
-If any test fails, fix it before continuing.
+If any test fails due to a source bug, create a GitHub issue (as in Step 3) before fixing it, then close it after.
 
 ### 6. Write the approval marker
 

--- a/.claude/skills/report-bug.md
+++ b/.claude/skills/report-bug.md
@@ -1,0 +1,51 @@
+Create a GitHub issue for a bug found during manual testing.
+
+## Steps
+
+### 1. Gather bug details
+
+Ask the user for:
+- A concise description of the bug (one sentence, will become the issue title)
+- What they observed (actual behaviour)
+- What they expected to happen
+- Steps to reproduce, if known
+
+If the user already provided this in their message, skip asking and use what they gave you.
+
+### 2. Create the issue
+
+Construct a title in the format `Bug: <concise description>` (capitalise the first word after "Bug:").
+
+Build a markdown body:
+
+```
+**Observed behaviour:** <what the user saw>
+
+**Expected behaviour:** <what should have happened>
+
+**Steps to reproduce:**
+<numbered list, or "not yet determined" if unknown>
+```
+
+Then run from the project root:
+
+```
+node scripts/bug-tracker.mjs create \
+  --title "Bug: <title>" \
+  --body "<body>" \
+  --source "manual"
+```
+
+If the output starts with `EXISTS:N`, tell the user the bug is already tracked as issue #N and give them the GitHub link.
+
+If the output starts with `CREATED:N`, confirm to the user: "Bug logged as issue #N: <GitHub issue URL>".
+
+The GitHub issue URL format is: `https://github.com/<owner>/<repo>/issues/<N>`. Resolve `<owner>/<repo>` with:
+
+```
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+### 3. Advise next steps
+
+Tell the user: when a fix is committed, include `Fixes #N` in the commit message and the issue will be closed automatically with the fix details.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit tests
@@ -22,7 +26,24 @@ jobs:
         run: npm ci
 
       - name: Run unit tests
+        id: unit-tests
         run: npm test -- --run --reporter=verbose
+        continue-on-error: true
+
+      - name: Create issue for unit test failure
+        if: steps.unit-tests.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/bug-tracker.mjs create \
+            --title "Bug: Unit tests failing on ${{ github.ref_name }}" \
+            --body "Unit tests failed in CI run [#${{ github.run_number }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) on commit \`${{ github.sha }}\` (\`${{ github.ref_name }}\`)." \
+            --source "ci-unit-tests"
+
+      - name: Fail if tests failed
+        if: steps.unit-tests.outcome == 'failure'
+        run: exit 1
 
   e2e-tests:
     name: E2E tests
@@ -42,15 +63,32 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run E2E tests
+        id: e2e-tests
         run: npm run test:e2e
+        continue-on-error: true
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: steps.e2e-tests.outcome == 'failure'
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+      - name: Create issue for E2E test failure
+        if: steps.e2e-tests.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/bug-tracker.mjs create \
+            --title "Bug: E2E tests failing on ${{ github.ref_name }}" \
+            --body "E2E tests failed in CI run [#${{ github.run_number }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) on commit \`${{ github.sha }}\` (\`${{ github.ref_name }}\`). Playwright report uploaded as a build artifact." \
+            --source "ci-e2e-tests"
+
+      - name: Fail if tests failed
+        if: steps.e2e-tests.outcome == 'failure'
+        run: exit 1
 
   build:
     name: Build check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,21 @@ Don't mix the two styles in the same file — they're incompatible.
 
 E2E tests in `tests/e2e/` clear `localStorage` and reload before every test so they're fully independent.
 
+## Bug tracking
+
+Bugs are automatically tracked as GitHub issues throughout the development workflow:
+
+| Source | How issues are created | How issues are closed |
+|---|---|---|
+| QA review (`/qa-review`) | Created for each bug found, before fixing | Closed with root cause + fix details after the fix |
+| Unit / E2E test failures (during QA) | Created when a test fails due to a source bug | Closed after the source fix is applied |
+| CI pipeline | Created automatically on any test job failure | Include `Fixes #N` in a commit message |
+| Manual testing | Run `/report-bug` and describe what you saw | Include `Fixes #N` in a commit message |
+
+**Auto-close via commit message**: any commit whose message contains `Fixes #N`, `Closes #N`, or `Resolves #N` triggers the `post-commit` hook, which comments on the issue with the fix summary and closes it.
+
+The core script is `scripts/bug-tracker.mjs` — it handles deduplication (won't create a second issue if one with the same title is already open).
+
 ## QA review and pull requests
 
 Before pushing a branch or creating a PR, QA review must pass. Run:
@@ -64,3 +79,4 @@ For direct pushes to main, run `/wiki-update` in Claude Code to trigger the same
 | `src/components/TaskCard.vue` | Display and edit mode for a single task |
 | `src/components/TaskColumn.vue` | Column with add-task form and drop zone |
 | `tests/e2e/helpers.js` | Shared Playwright helpers (`addTask`, `taskCard`, `openEdit`) |
+| `scripts/bug-tracker.mjs` | CLI for creating and closing GitHub bug issues |

--- a/scripts/bug-tracker.mjs
+++ b/scripts/bug-tracker.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Usage:
+//   node scripts/bug-tracker.mjs create --title "..." --body "..." --source "qa-review|unit-test|e2e-test|manual|ci"
+//   node scripts/bug-tracker.mjs close  --number 42 --cause "..." --fix "..."
+//   node scripts/bug-tracker.mjs find   --title "..."   → prints issue number, or nothing
+import { spawnSync } from 'child_process';
+import { writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function parseArgs(argv) {
+  const opts = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i]?.startsWith('--') && argv[i + 1] !== undefined && !argv[i + 1].startsWith('--')) {
+      opts[argv[i].slice(2)] = argv[i + 1];
+      i++;
+    } else if (argv[i]?.startsWith('--')) {
+      opts[argv[i].slice(2)] = '';
+    }
+  }
+  return opts;
+}
+
+function gh(...args) {
+  const r = spawnSync('gh', args, { encoding: 'utf8' });
+  if (r.error) throw r.error;
+  if (r.status !== 0) throw new Error(r.stderr?.trim() || `gh exited with status ${r.status}`);
+  return r.stdout.trim();
+}
+
+function withTempFile(content, fn) {
+  const path = join(tmpdir(), `bug-tracker-${process.pid}-${Date.now()}.md`);
+  writeFileSync(path, content, 'utf8');
+  try {
+    return fn(path);
+  } finally {
+    try { unlinkSync(path); } catch {}
+  }
+}
+
+function ensureBugLabel() {
+  try {
+    gh('label', 'create', 'bug', '--color', 'd73a4a', '--description', "Something isn't working", '--force');
+  } catch {}
+}
+
+function openBugIssues() {
+  const out = gh('issue', 'list', '--label', 'bug', '--state', 'open', '--json', 'title,number', '--limit', '100');
+  return JSON.parse(out);
+}
+
+const [,, command, ...rest] = process.argv;
+const opts = parseArgs(rest);
+
+if (command === 'create') {
+  const { title, body = '', source = 'unknown' } = opts;
+  if (!title) { console.error('--title is required'); process.exit(1); }
+
+  ensureBugLabel();
+
+  const existing = openBugIssues();
+  const dup = existing.find(i => i.title === title);
+  if (dup) {
+    process.stdout.write(`EXISTS:${dup.number}\n`);
+    process.exit(0);
+  }
+
+  const fullBody = `**Detected by:** ${source}\n\n${body}`;
+  const url = withTempFile(fullBody, f =>
+    gh('issue', 'create', '--title', title, '--body-file', f, '--label', 'bug')
+  );
+  const num = url.match(/\/(\d+)$/)?.[1];
+  if (num) process.stdout.write(`CREATED:${num}\n`);
+
+} else if (command === 'close') {
+  const { number, cause = 'See linked commit', fix = 'See linked commit' } = opts;
+  if (!number) { console.error('--number is required'); process.exit(1); }
+
+  const comment = `**Bug resolved.**\n\n**Root cause:** ${cause}\n\n**Fix applied:** ${fix}`;
+  withTempFile(comment, f => gh('issue', 'comment', number, '--body-file', f));
+  gh('issue', 'close', number);
+  process.stdout.write(`CLOSED:${number}\n`);
+
+} else if (command === 'find') {
+  const { title } = opts;
+  if (!title) { console.error('--title is required'); process.exit(1); }
+
+  const existing = openBugIssues();
+  const found = existing.find(i => i.title === title);
+  if (found) process.stdout.write(`${found.number}\n`);
+
+} else {
+  console.error(`Unknown command: ${command}`);
+  console.error('Commands: create, close, find');
+  process.exit(1);
+}

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -9,4 +9,6 @@ cp scripts/post-checkout .git/hooks/post-checkout
 chmod +x .git/hooks/post-checkout
 cp scripts/pre-push .git/hooks/pre-push
 chmod +x .git/hooks/pre-push
+cp scripts/post-commit .git/hooks/post-commit
+chmod +x .git/hooks/post-commit
 echo "Git hooks installed."

--- a/scripts/post-commit
+++ b/scripts/post-commit
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Auto-close GitHub bug issues referenced in commit messages.
+# Recognises: "Fixes #N", "Closes #N", "Resolves #N" (case-insensitive).
+# Skips execution inside worktrees — only fires in the main repo checkout.
+
+git_dir=$(git rev-parse --git-dir)
+if [ -f "${git_dir}/commondir" ]; then
+  exit 0
+fi
+
+msg=$(git log -1 --pretty=%B)
+
+numbers=$(printf '%s' "$msg" | grep -oiE '(fixes|closes|resolves)[[:space:]]+#[0-9]+' | grep -oE '[0-9]+')
+
+if [ -z "$numbers" ]; then
+  exit 0
+fi
+
+fix_summary=$(git log -1 --pretty=%s)
+
+for num in $numbers; do
+  node scripts/bug-tracker.mjs close \
+    --number "$num" \
+    --cause "See linked commit for root cause" \
+    --fix "$fix_summary" 2>/dev/null || true
+done


### PR DESCRIPTION
## Summary

- **`scripts/bug-tracker.mjs`** — core CLI with three commands: `create` (opens a `bug`-labelled issue with deduplication), `close` (comments with root cause + fix, then closes), and `find` (look up by title)
- **`scripts/post-commit`** — git hook that scans commit messages for `Fixes #N` / `Closes #N` / `Resolves #N` and auto-closes the matching issue with the commit subject as the fix summary; skips in worktrees
- **`.claude/skills/report-bug.md`** — `/report-bug` skill for manually discovered bugs; gathers observed/expected behaviour and reproduction steps, then calls `bug-tracker.mjs`
- **`.claude/skills/qa-review.md`** — updated so QA creates an issue for each code bug *before* fixing it, and closes it after with cause + fix details; same for test failures that represent source bugs
- **`.github/workflows/ci.yml`** — both test jobs now create a GitHub issue on failure (`continue-on-error: true` so fork PRs with restricted tokens don't add noise); `issues: write` permission added
- **`scripts/install-hooks.sh`** — installs the new `post-commit` hook alongside the existing ones
- **`CLAUDE.md`** — new "Bug tracking" section documenting all four sources and the auto-close mechanism

## How it fits together

| Source | Issue created | Issue closed |
|---|---|---|
| `/qa-review` | Before each fix, by the skill | After each fix, by the skill |
| Unit/E2E failures during QA | Before fix, by the skill | After fix, by the skill |
| CI pipeline | Automatically on any test job failure | Via `Fixes #N` in a commit message |
| Manual testing | Via `/report-bug` skill | Via `Fixes #N` in a commit message |

## Test plan

- [ ] Existing 231 unit tests pass (verified in QA review)
- [ ] `scripts/bug-tracker.mjs` — run `node scripts/bug-tracker.mjs` with no args to confirm usage error output
- [ ] Confirm `gh label create bug --force` is idempotent if the label already exists
- [ ] Make a commit with `Fixes #N` in the message and confirm the post-commit hook closes the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)