### PR TITLE
Add mark-qa-approved.sh for manual developer QA workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,15 @@ The `pre-push` git hook and the Claude Code `PreToolUse` hook both enforce this 
 
 To re-approve after adding commits, just run `/qa-review` again.
 
+**Working without Claude Code?** Run the manual equivalent instead:
+
+```
+sh scripts/mark-qa-approved.sh        # unit tests + writes marker
+sh scripts/mark-qa-approved.sh --e2e  # also runs E2E tests
+```
+
+This runs the test suite and writes the same approval marker. You are responsible for the code review itself — the script only verifies the tests pass.
+
 ## Wiki updates
 
 The [GitHub wiki](https://github.com/lauz9888/untangle/wiki) is updated automatically. When a PR is merged and main is pushed, a GitHub Actions workflow (`wiki-update.yml`) diffs the change against every wiki page and updates any that are out of date. It requires `ANTHROPIC_API_KEY` to be set as a repository secret.

--- a/scripts/check-qa-approved.sh
+++ b/scripts/check-qa-approved.sh
@@ -18,7 +18,8 @@ if [ ! -f "$marker" ]; then
   echo ""
   echo "QA REVIEW REQUIRED"
   echo "  Branch '${branch}' has not been QA reviewed."
-  echo "  Run /qa-review in Claude Code before creating a pull request."
+  echo "  Claude Code:  run /qa-review"
+  echo "  Manual:       sh scripts/mark-qa-approved.sh"
   echo ""
   exit 1
 fi
@@ -30,7 +31,8 @@ if [ "$approved_commit" != "$current_commit" ]; then
   echo "  New commits have been added since the last QA review."
   echo "  Approved commit: ${approved_commit}"
   echo "  Current commit:  ${current_commit}"
-  echo "  Re-run /qa-review in Claude Code before creating a pull request."
+  echo "  Claude Code:  re-run /qa-review"
+  echo "  Manual:       sh scripts/mark-qa-approved.sh"
   echo ""
   exit 1
 fi

--- a/scripts/mark-qa-approved.sh
+++ b/scripts/mark-qa-approved.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Manually approve the current branch for push/PR after a human code review.
+# Runs unit tests (and optionally E2E tests) then writes the QA approval marker.
+#
+# Usage:
+#   sh scripts/mark-qa-approved.sh          # unit tests only
+#   sh scripts/mark-qa-approved.sh --e2e    # unit + E2E tests
+
+set -e
+
+run_e2e=false
+for arg in "$@"; do
+  case "$arg" in
+    --e2e) run_e2e=true ;;
+    *)
+      echo "Unknown option: $arg"
+      echo "Usage: sh scripts/mark-qa-approved.sh [--e2e]"
+      exit 1
+      ;;
+  esac
+done
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  echo "Already on main/master — no approval marker needed."
+  exit 0
+fi
+
+# Resolve project root (worktree-aware — node_modules lives in the main repo)
+git_dir=$(git rev-parse --git-dir)
+if [ -f "${git_dir}/commondir" ]; then
+  common=$(cat "${git_dir}/commondir")
+  project_root=$(cd "${git_dir}/${common}/.." && pwd)
+else
+  project_root=$(git rev-parse --show-toplevel)
+fi
+
+echo "Running unit tests..."
+cd "$project_root" && npm test -- --run
+
+if [ "$run_e2e" = true ]; then
+  echo "Running E2E tests..."
+  cd "$project_root" && npm run test:e2e
+fi
+
+safe_branch=$(echo "$branch" | tr '/' '_' | tr '\\' '_')
+mkdir -p "${git_dir}/claude-qa"
+commit=$(git rev-parse HEAD | tr -d '[:space:]')
+printf '%s' "$commit" > "${git_dir}/claude-qa/${safe_branch}.approved"
+
+echo ""
+echo "QA approved for '${branch}' at ${commit}"
+echo "You may now push and open a pull request."


### PR DESCRIPTION
## Summary

- **`scripts/mark-qa-approved.sh`** — new script: runs the test suite (`--e2e` flag for E2E too) and writes the QA approval marker, giving contributors without Claude Code a first-class way to satisfy the pre-push gate
- **`scripts/check-qa-approved.sh`** — both blocked-state error messages now show both options (`/qa-review` and `sh scripts/mark-qa-approved.sh`) side by side
- **`CLAUDE.md`** — documents the manual path under the QA review section
- **Wiki `Developer-Workflow.md`** — diagram updated with a `Claude Code or manual?` fork that routes to either `/qa-review` or `mark-qa-approved.sh`; helper scripts table updated; `pre-push` section now lists both unblock options

## What the script does

```sh
sh scripts/mark-qa-approved.sh        # unit tests only
sh scripts/mark-qa-approved.sh --e2e  # unit + E2E
```

Runs tests, then writes `.git/claude-qa/<branch>.approved` with the current commit hash — the same file the `/qa-review` skill writes. The code review judgement remains the contributor's responsibility.

## Test plan

- [ ] Existing 231 unit tests pass (verified)
- [ ] Run `sh scripts/mark-qa-approved.sh` on a branch and confirm the marker file is created with the correct hash
- [ ] Confirm `git push` proceeds on a branch marked approved by the script
- [ ] Confirm blocked-state error messages now show both options

🤖 Generated with [Claude Code](https://claude.com/claude-code)