### PR TITLE
Show energy selector label on mobile

### DIFF
--- a/src/components/EnergySelector.vue
+++ b/src/components/EnergySelector.vue
@@ -76,10 +76,6 @@ const { currentEnergy } = useTasks()
     justify-content: space-between;
   }
 
-  .energy-label {
-    display: none;
-  }
-
   .energy-buttons {
     flex: 1;
     justify-content: space-between;

--- a/tests/e2e/mobile.spec.js
+++ b/tests/e2e/mobile.spec.js
@@ -152,6 +152,10 @@ test.describe('mobile — layout at narrow viewport', () => {
     await expect(page.locator('.app-title')).toBeVisible()
   })
 
+  test('energy selector label is visible at narrow viewport', async ({ page }) => {
+    await expect(page.locator('.energy-label')).toBeVisible()
+  })
+
   test('action buttons are present in the DOM and functional on narrow viewport', async ({ page }) => {
     await addTask(page, 'now', 'Mobile task')
     const card = taskCard(page, 'now', 'Mobile task')


### PR DESCRIPTION
## Summary

- The \"Energy\" label in the header filter was hidden on mobile (`display: none`), leaving users with no indication of what the filter buttons do
- Removed the hide rule — the existing flex layout (`justify-content: space-between` on the container, `flex: 1` on the button group) handles the label naturally with no further changes needed

## Test plan

- [x] Unit tests pass (234/234)
- [x] Added E2E assertion: `.energy-label` is visible at 390px viewport (`mobile — layout at narrow viewport`)
- [ ] Visual check: energy selector on a narrow mobile viewport shows \"Energy\" label to the left of the buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)