### PR TITLE
Track bug detection process as GitHub labels and add development source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,14 +36,26 @@ E2E tests in `tests/e2e/` clear `localStorage` and reload before every test so t
 
 ## Bug tracking
 
-Bugs are automatically tracked as GitHub issues throughout the development workflow:
+Bugs are tracked as GitHub issues whenever they are identified, regardless of the process that found them. Every issue records which process detected the bug — both in the issue body (`**Detected by:**`) and as a GitHub label (`found:development`, `found:qa`, `found:ci`, or `found:manual`) so issues can be filtered by detection process.
 
-| Source | How issues are created | How issues are closed |
-|---|---|---|
-| QA review (`/qa-review`) | Created for each bug found, before fixing | Closed with root cause + fix details after the fix |
-| Unit / E2E test failures (during QA) | Created when a test fails due to a source bug | Closed after the source fix is applied |
-| CI pipeline | Created automatically on any test job failure | Include `Fixes #N` in a commit message |
-| Manual testing | Run `/report-bug` and describe what you saw | Include `Fixes #N` in a commit message |
+| Process | Source value | How issues are created | How issues are closed |
+|---|---|---|---|
+| Development | `development` | Create before fixing with `--source development` (see below) | Include `Fixes #N` in the commit message |
+| QA review (`/qa-review`) | `qa-review` | Created for each bug found, before fixing | Closed with root cause + fix details after the fix |
+| Unit / E2E test failures (during QA) | `unit-test` / `e2e-test` | Created when a test fails due to a source bug | Closed after the source fix is applied |
+| CI pipeline | `ci-unit-tests` / `ci-e2e-tests` | Created automatically on any test job failure | Include `Fixes #N` in a commit message |
+| Manual report | `manual` | Run `/report-bug` and describe what you saw | Include `Fixes #N` in a commit message |
+
+**Reporting a development-time bug**: if you spot a bug in existing code while implementing a feature (before the QA step), create an issue before fixing it:
+
+```
+node scripts/bug-tracker.mjs create \
+  --title "Bug: <concise description>" \
+  --body "<what the bug is, which file and line, how it manifests>" \
+  --source "development"
+```
+
+Then fix the bug and include `Fixes #N` in the commit message to close the issue automatically.
 
 **Auto-close via commit message**: any commit whose message contains `Fixes #N`, `Closes #N`, or `Resolves #N` triggers the `post-commit` hook, which comments on the issue with the fix summary and closes it.
 

--- a/scripts/bug-tracker.mjs
+++ b/scripts/bug-tracker.mjs
@@ -1,12 +1,23 @@
 #!/usr/bin/env node
 // Usage:
-//   node scripts/bug-tracker.mjs create --title "..." --body "..." --source "qa-review|unit-test|e2e-test|manual|ci"
+//   node scripts/bug-tracker.mjs create --title "..." --body "..." --source "development|qa-review|unit-test|e2e-test|manual|ci-unit-tests|ci-e2e-tests"
 //   node scripts/bug-tracker.mjs close  --number 42 --cause "..." --fix "..."
 //   node scripts/bug-tracker.mjs find   --title "..."   → prints issue number, or nothing
 import { spawnSync } from 'child_process';
 import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+
+// Maps source values to a GitHub label that records the detection process.
+const PROCESS_LABELS = {
+  'development':   { name: 'found:development', color: '0075ca', description: 'Identified during development' },
+  'qa-review':     { name: 'found:qa',          color: 'e4e669', description: 'Identified during QA review' },
+  'unit-test':     { name: 'found:qa',          color: 'e4e669', description: 'Identified during QA review' },
+  'e2e-test':      { name: 'found:qa',          color: 'e4e669', description: 'Identified during QA review' },
+  'ci-unit-tests': { name: 'found:ci',          color: 'd876e3', description: 'Identified in CI pipeline' },
+  'ci-e2e-tests':  { name: 'found:ci',          color: 'd876e3', description: 'Identified in CI pipeline' },
+  'manual':        { name: 'found:manual',      color: '0e8a16', description: 'Reported manually' },
+};
 
 function parseArgs(argv) {
   const opts = {};
@@ -44,6 +55,15 @@ function ensureBugLabel() {
   } catch {}
 }
 
+function ensureProcessLabel(source) {
+  const meta = PROCESS_LABELS[source];
+  if (!meta) return null;
+  try {
+    gh('label', 'create', meta.name, '--color', meta.color, '--description', meta.description, '--force');
+  } catch {}
+  return meta.name;
+}
+
 function openBugIssues() {
   const out = gh('issue', 'list', '--label', 'bug', '--state', 'open', '--json', 'title,number', '--limit', '100');
   return JSON.parse(out);
@@ -57,6 +77,7 @@ if (command === 'create') {
   if (!title) { console.error('--title is required'); process.exit(1); }
 
   ensureBugLabel();
+  const processLabel = ensureProcessLabel(source);
 
   const existing = openBugIssues();
   const dup = existing.find(i => i.title === title);
@@ -66,8 +87,11 @@ if (command === 'create') {
   }
 
   const fullBody = `**Detected by:** ${source}\n\n${body}`;
+  const labelArgs = processLabel
+    ? ['--label', 'bug', '--label', processLabel]
+    : ['--label', 'bug'];
   const url = withTempFile(fullBody, f =>
-    gh('issue', 'create', '--title', title, '--body-file', f, '--label', 'bug')
+    gh('issue', 'create', '--title', title, '--body-file', f, ...labelArgs)
   );
   const num = url.match(/\/(\d+)$/)?.[1];
   if (num) process.stdout.write(`CREATED:${num}\n`);


### PR DESCRIPTION
Every bug issue now receives a process label (found:development,
found:qa, found:ci, found:manual) in addition to the body text, so
issues can be filtered by which process surfaced the bug. Adds
'development' as a valid source for bugs spotted while coding, with
instructions in CLAUDE.md on when and how to report them before fixing.

https://claude.ai/code/session_01JJ2unEFn3CCVNhnAJJMT5j