### PR TITLE
Add structured developer workflow with automated skill pipeline

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/workflow-state.mjs check-prompt"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/workflow-state.mjs check-transition"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/deploy-branch.md
+++ b/.claude/skills/deploy-branch.md
@@ -1,0 +1,93 @@
+Run CI checks and deploy the change to a branch for manual testing.
+
+This skill is part of the automated development workflow. It runs automatically when the developer chooses to test manually after document-analysis, or can be invoked manually with `/deploy-branch`.
+
+## Steps
+
+### 1. Read current workflow state
+
+```
+node scripts/workflow-state.mjs get
+```
+
+`docs_done` must be true before proceeding.
+
+Determine the project root for running npm commands (handles worktrees):
+
+```
+git_dir=$(git rev-parse --git-dir)
+if [ -f "${git_dir}/commondir" ]; then
+  common=$(cat "${git_dir}/commondir")
+  project_root=$(cd "${git_dir}/${common}/.." && pwd)
+else
+  project_root=$(git rev-parse --show-toplevel)
+fi
+```
+
+### 2. Run CI checks in order
+
+Run each check individually. Fix any failures before continuing to the next check.
+
+**Build check:**
+```
+cd $project_root && npm run build
+```
+
+**Unit tests (full suite):**
+```
+cd $project_root && npm test -- --run
+```
+
+**E2E tests (full suite):**
+```
+cd $project_root && npm run test:e2e
+```
+
+For each test failure caused by a real source bug (not infrastructure), trigger `/report-bug` before fixing — use source `ci-unit-tests` for unit test failures or `ci-e2e-tests` for e2e failures. Provide the failure message and location. After the issue is created and the bug is fixed, re-run the failing suite to confirm it passes before continuing.
+
+### 3. Stage and commit all changes
+
+Review what will be committed:
+
+```
+git diff --stat
+git status
+```
+
+Commit the full change (implementation + tests + docs):
+
+```
+git add <specific files — not git add -A>
+git commit -m "<summary of what was implemented>
+
+<brief details if needed>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+### 4. Push to the branch
+
+```
+git push -u origin HEAD
+```
+
+Confirm the current branch name:
+
+```
+git branch --show-current
+```
+
+### 5. Report to the developer
+
+Tell the developer:
+- The branch name and that it's been pushed
+- How to access this version locally: `git checkout <branch>` then `npm run dev` (or provide a preview URL if one is generated)
+- All CI checks passed
+
+Then ask:
+
+> "The branch is ready for manual testing. Once you've tested, let me know when you're happy and I'll run `/deploy-main` to merge to main."
+
+### 6. Wait
+
+Do not advance the workflow automatically from here. The developer will trigger `/deploy-main` when they're ready.

--- a/.claude/skills/deploy-main.md
+++ b/.claude/skills/deploy-main.md
@@ -1,0 +1,120 @@
+Run the full CI pipeline and deploy the change to main.
+
+This skill is part of the automated development workflow. It runs automatically when the developer chooses to skip branch testing, or is triggered manually with `/deploy-main` after branch testing.
+
+## Steps
+
+### 1. Read current workflow state
+
+```
+node scripts/workflow-state.mjs get
+```
+
+`docs_done` must be true before proceeding.
+
+Determine the project root for running npm commands (handles worktrees):
+
+```
+git_dir=$(git rev-parse --git-dir)
+if [ -f "${git_dir}/commondir" ]; then
+  common=$(cat "${git_dir}/commondir")
+  project_root=$(cd "${git_dir}/${common}/.." && pwd)
+else
+  project_root=$(git rev-parse --show-toplevel)
+fi
+```
+
+### 2. Run CI checks in order
+
+Run each check individually. Fix any failures before continuing.
+
+**Build check:**
+```
+cd $project_root && npm run build
+```
+
+**Unit tests (full suite):**
+```
+cd $project_root && npm test -- --run
+```
+
+**E2E tests (full suite):**
+```
+cd $project_root && npm run test:e2e
+```
+
+For each test failure caused by a real source bug, trigger `/report-bug` before fixing — use source `ci-unit-tests` for unit test failures or `ci-e2e-tests` for e2e failures. Provide the failure message and location. After the issue is created and the bug is fixed, re-run to confirm.
+
+### 3. Stage and commit all changes (if not already committed)
+
+Check whether the changes have been committed:
+
+```
+git status
+git log --oneline main...HEAD
+```
+
+If there are uncommitted changes, commit them:
+
+```
+git add <specific files>
+git commit -m "<summary>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+### 4. Write the QA approval marker
+
+All CI checks have passed. Write the approval marker so the pre-push hook allows the push:
+
+```
+git_dir=$(git rev-parse --git-dir)
+branch=$(git branch --show-current)
+safe_branch=$(echo "$branch" | tr '/\\' '_')
+mkdir -p "${git_dir}/claude-qa"
+git rev-parse HEAD > "${git_dir}/claude-qa/${safe_branch}.approved"
+```
+
+### 5. Create a pull request and merge
+
+Create the PR:
+
+```
+gh pr create \
+  --title "<concise title of the change>" \
+  --body "$(cat <<'EOF'
+## Summary
+- <bullet 1>
+- <bullet 2>
+
+## Test plan
+- [x] Unit tests updated and passing
+- [x] E2E tests updated and passing
+- [x] Build passes
+- [x] Documentation updated
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Get the PR number from the output, then merge:
+
+```
+gh pr merge <PR-number> --squash --delete-branch
+```
+
+### 6. Reset workflow state
+
+```
+node scripts/workflow-state.mjs reset
+```
+
+### 7. Report to the developer
+
+Tell the developer:
+- The PR number and that it has been merged to main
+- The source branch has been deleted
+- The full workflow is complete
+
+If the wiki auto-update workflow is running, mention that it will update the GitHub wiki automatically.

--- a/.claude/skills/document-analysis.md
+++ b/.claude/skills/document-analysis.md
@@ -1,0 +1,68 @@
+Review and update documentation to reflect the completed change, then confirm the developer's preferred deployment path.
+
+This skill is part of the automated development workflow. It runs automatically after e2e-test-analysis completes, or can be invoked manually with `/document-analysis`.
+
+## Steps
+
+### 1. Read current workflow state
+
+```
+node scripts/workflow-state.mjs get
+```
+
+`e2e_tests_done` must be true before proceeding.
+
+### 2. Review documentation
+
+Check every `.md` file that was touched in the branch, plus `README.md` and `CLAUDE.md` regardless of whether they were changed:
+
+```
+git diff main...HEAD --name-only
+```
+
+For each doc, ask:
+- Does it describe something that now works differently?
+- Is there a new feature, command, file, or architectural concept that should be mentioned?
+- Is there anything now incorrect or misleading?
+
+Update where the answer is yes. Only document user-facing or contributor-facing information — not internal implementation details.
+
+If the change adds a new skill, updates workflow state commands, or changes the development workflow itself, update the **Developer workflow** section in `CLAUDE.md`.
+
+### 3. Advance the docs step
+
+```
+node scripts/workflow-state.mjs approve docs
+```
+
+### 4. Summarise and ask about deployment
+
+Give the developer a concise summary of everything done in this workflow:
+- What was built (the requirement)
+- What changed (files modified)
+- Test results (unit + e2e)
+- Doc updates made (or "none needed")
+
+Then ask:
+
+> "Everything is complete. Would you like to:
+> - **Test manually first** — I'll deploy the changes to a branch so you can verify in a browser before merging
+> - **Deploy directly to main** — I'll run the full CI pipeline and merge straight to main"
+
+Wait for their response before advancing. Do not set a next step automatically here.
+
+### 5. Route to the chosen deployment path
+
+If the developer wants to test manually:
+```
+node scripts/workflow-state.mjs set pending_next_step "deploy-branch"
+```
+Tell them: "Deploying to a branch for manual testing now."
+
+If the developer wants to deploy directly to main:
+```
+node scripts/workflow-state.mjs set pending_next_step "deploy-main"
+```
+Tell them: "Running the full pipeline and deploying to main now."
+
+The Stop hook will automatically start the appropriate deployment skill.

--- a/.claude/skills/e2e-test-analysis.md
+++ b/.claude/skills/e2e-test-analysis.md
@@ -1,0 +1,66 @@
+Review end-to-end tests for the completed change and update them as needed.
+
+This skill is part of the automated development workflow. It runs automatically after unit-test-analysis completes, or can be invoked manually with `/e2e-test-analysis`.
+
+## Steps
+
+### 1. Read current workflow state
+
+```
+node scripts/workflow-state.mjs get
+```
+
+`unit_tests_done` must be true before proceeding.
+
+Determine the project root for running npm commands (handles worktrees):
+
+```
+git_dir=$(git rev-parse --git-dir)
+if [ -f "${git_dir}/commondir" ]; then
+  common=$(cat "${git_dir}/commondir")
+  project_root=$(cd "${git_dir}/${common}/.." && pwd)
+else
+  project_root=$(git rev-parse --show-toplevel)
+fi
+```
+
+### 2. Identify which e2e tests are affected
+
+Read all files in `tests/e2e/` and cross-reference with the git diff:
+
+```
+git diff main...HEAD --name-only
+```
+
+An e2e test needs to change when:
+- A user-visible feature is added or changed
+- A new interaction flow exists (drag, edit, delete, toggle, form submission)
+- A bug fix addresses something a user would notice
+
+E2E tests live in `tests/e2e/<feature>.spec.js` and use shared helpers from `tests/e2e/helpers.js`. Every test clears `localStorage` and reloads before running. Read existing tests before writing new ones and match their patterns exactly.
+
+### 3. Make the required changes
+
+Add, remove, or update e2e tests to cover the change. If no e2e test changes are needed, note this and skip to step 5.
+
+### 4. Run the affected tests
+
+The E2E suite spins up its own dev server via `playwright.config.js`:
+
+```
+cd $project_root && npm run test:e2e -- <test-file-pattern>
+```
+
+If a test fails because of a real bug in the source, trigger `/report-bug` with source `e2e-test` before fixing. Provide the test file, line, failure message, and what the test exercises. After the issue is created and the bug is fixed, re-run to confirm the tests pass.
+
+### 5. Advance to document analysis
+
+```
+node scripts/workflow-state.mjs approve e2e-tests
+```
+
+### 6. Confirm to the developer
+
+Tell the developer: "E2E tests updated and passing. Moving to documentation review now."
+
+The Stop hook will automatically start `/document-analysis`.

--- a/.claude/skills/implementation-analysis.md
+++ b/.claude/skills/implementation-analysis.md
@@ -1,0 +1,62 @@
+Review the completed implementation against the approved requirement and solution to confirm it is correct, complete, and maintainable.
+
+This skill is part of the automated development workflow. It runs automatically after solution-implementation completes, or can be invoked manually with `/implementation-analysis`.
+
+## Steps
+
+### 1. Read current workflow state
+
+```
+node scripts/workflow-state.mjs get
+```
+
+The `requirement_text`, `solution_text`, and `implementation_summary` fields define what was asked for and what was built. Both requirements and solution must be approved.
+
+### 2. Review the implementation against the spec
+
+Read the git diff since main:
+
+```
+git diff main...HEAD
+```
+
+For every changed file, verify:
+
+- **Requirement coverage** — does the implementation deliver everything in `requirement_text`? Is anything missing?
+- **Solution conformance** — does the implementation match the approach described in `solution_text`? If it deviated, was the deviation justified?
+- **Correctness** — are there logic errors, off-by-one issues, unhandled edge cases described in the requirements?
+- **Scope creep** — were any changes made beyond the agreed scope?
+
+### 3. Fix any bugs found
+
+For each bug found, trigger `/report-bug` with source `qa-review` before fixing it. Provide the title, file/line, and how it manifests. After the issue is created and the bug is fixed, continue the review.
+
+### 4. Loop back if the gap is fundamental
+
+If the implementation is missing something because the **requirement was ambiguous** (the gap was not visible during requirement-analysis):
+
+```
+node scripts/workflow-state.mjs loop-back requirement-analysis "Implementation review found requirement gap: [what is unclear or missing]"
+```
+
+If the implementation is missing something because the **solution design was wrong** (e.g. wrong files targeted, wrong abstraction used):
+
+```
+node scripts/workflow-state.mjs loop-back solution-analysis "Implementation review found solution design issue: [what needs to change in the approach]"
+```
+
+Tell the developer what happened. The Stop hook will route automatically.
+
+### 5. Approve the implementation
+
+When the implementation correctly delivers the approved requirement with no outstanding issues:
+
+```
+node scripts/workflow-state.mjs approve implementation
+```
+
+### 6. Confirm to the developer
+
+Tell the developer: "Implementation verified. Moving to unit test analysis now."
+
+The Stop hook will automatically start `/unit-test-analysis`.

--- a/.claude/skills/report-bug.md
+++ b/.claude/skills/report-bug.md
@@ -1,51 +1,66 @@
-Create a GitHub issue for a bug found during manual testing.
+Create a GitHub issue for any bug, wherever it was found.
+
+This skill is triggered automatically by workflow skills when they identify a bug, and can be run manually by the developer with `/report-bug` at any time.
+
+## Bug sources
+
+Each context maps to a source label used to track where bugs are detected:
+
+| Where the bug was found | Source value |
+|---|---|
+| During code writing (`/solution-implementation`) | `development` |
+| During code review (`/implementation-analysis`) | `qa-review` |
+| Unit test failure (`/unit-test-analysis`) | `unit-test` |
+| E2E test failure (`/e2e-test-analysis`) | `e2e-test` |
+| Unit test failure during CI (`/deploy-branch`, `/deploy-main`) | `ci-unit-tests` |
+| E2E test failure during CI (`/deploy-branch`, `/deploy-main`) | `ci-e2e-tests` |
+| Developer found during manual browser testing | `manual` |
 
 ## Steps
 
 ### 1. Gather bug details
 
-Ask the user for:
-- A concise description of the bug (one sentence, will become the issue title)
+**If triggered by a workflow skill**, the triggering skill provides:
+- Source (from the table above)
+- A concise one-sentence title
+- What was observed, which file and line, how it manifests
+
+Use this information directly — do not ask the developer to repeat it.
+
+**If run manually by the developer**, ask for:
+- A concise description of the bug (one sentence, becomes the issue title)
 - What they observed (actual behaviour)
 - What they expected to happen
+- Where in the code this seems to be (file and line if known)
 - Steps to reproduce, if known
-
-If the user already provided this in their message, skip asking and use what they gave you.
 
 ### 2. Create the issue
 
-Construct a title in the format `Bug: <concise description>` (capitalise the first word after "Bug:").
-
-Build a markdown body:
-
-```
-**Observed behaviour:** <what the user saw>
-
-**Expected behaviour:** <what should have happened>
-
-**Steps to reproduce:**
-<numbered list, or "not yet determined" if unknown>
-```
-
-Then run from the project root:
-
 ```
 node scripts/bug-tracker.mjs create \
-  --title "Bug: <title>" \
-  --body "<body>" \
-  --source "manual"
+  --title "Bug: <concise description>" \
+  --body "<observed behaviour, file/line, how it manifests>" \
+  --source "<source value from table>"
 ```
 
-If the output starts with `EXISTS:N`, tell the user the bug is already tracked as issue #N and give them the GitHub link.
+If the output starts with `EXISTS:N` — already tracked as issue #N. Note the number and continue.
+If the output starts with `CREATED:N` — now tracked as issue #N. Note the number and continue.
 
-If the output starts with `CREATED:N`, confirm to the user: "Bug logged as issue #N: <GitHub issue URL>".
+### 3. Fix the bug
 
-The GitHub issue URL format is: `https://github.com/<owner>/<repo>/issues/<N>`. Resolve `<owner>/<repo>` with:
+Fix the underlying issue. Keep the fix minimal and targeted — do not refactor surrounding code.
+
+### 4. Close the issue
 
 ```
-gh repo view --json nameWithOwner -q .nameWithOwner
+node scripts/bug-tracker.mjs close \
+  --number <N> \
+  --cause "<root cause — why the bug existed>" \
+  --fix "<what was changed to fix it>"
 ```
 
-### 3. Advise next steps
+### 5. Return or advise
 
-Tell the user: when a fix is committed, include `Fixes #N` in the commit message and the issue will be closed automatically with the fix details.
+**If triggered by a workflow skill:** return to that skill and continue from where you left off. The issue is now resolved.
+
+**If run manually:** tell the developer "Bug logged as issue #N. To close it automatically, include `Fixes #N` in your commit message."

--- a/.claude/skills/requirement-analysis.md
+++ b/.claude/skills/requirement-analysis.md
@@ -1,0 +1,71 @@
+Capture and validate the full requirements for a code change before any solution work begins.
+
+This skill is part of the automated development workflow. It runs at the start of every change — either triggered automatically when a change request is detected, or invoked manually with `/requirement-analysis`.
+
+## Steps
+
+### 1. Read current workflow state
+
+```
+node scripts/workflow-state.mjs get
+```
+
+If the state shows `loop_back_reason`, this is a loop-back from a later step (solution or implementation). Acknowledge this context upfront — e.g. "I was sent back here from solution-analysis because [reason]. Let me revisit the requirements with that in mind."
+
+If `requirement_text` already has content, start from that as a draft rather than asking from scratch.
+
+If no state exists yet, initialise it:
+
+```
+node scripts/workflow-state.mjs start
+```
+
+### 2. Establish the requirement
+
+Ask the developer what they want to change or build. Keep asking until you have clear answers to all of:
+
+- **What** — the exact behaviour or feature being added/changed/removed
+- **Why** — the goal or problem this solves (helps detect scope creep later)
+- **Scope** — what is explicitly out of scope (what should NOT change)
+- **Acceptance criteria** — how you'll know when it's done correctly
+- **Edge cases** — unusual inputs, states, or user paths that must be handled
+- **Constraints** — performance requirements, accessibility needs, compatibility concerns
+
+Ask one focused question at a time. Don't ask for everything at once.
+
+If the developer's initial message already answers most of these, confirm your understanding rather than re-asking. For example: "I understand you want to [X], which should [Y], and it's done when [Z]. Is that right?"
+
+### 3. Review for conflicts
+
+Once you have the requirement, check the codebase for anything that could contradict or interfere with it:
+
+```
+git diff main...HEAD --name-only
+```
+
+Read the relevant source files and identify:
+- Existing functionality that overlaps with or depends on what's being changed
+- State, events, or composables that the change will touch
+- Other features that could break if the change is implemented naively
+
+If you find a conflict or dependency, raise it explicitly: "This change will affect [X], which is also used by [Y]. We need to decide whether [Y] should change too."
+
+### 4. Save the approved requirements
+
+When the developer confirms the requirements are correct, write a concise but complete summary to state:
+
+```
+node scripts/workflow-state.mjs set requirement_text "SUMMARY: <what>. GOAL: <why>. SCOPE: <what's in/out>. ACCEPTANCE: <criteria>. CONSTRAINTS: <any>."
+```
+
+Then approve the requirement step to trigger solution-analysis automatically:
+
+```
+node scripts/workflow-state.mjs approve requirement
+```
+
+### 5. Confirm to the developer
+
+Tell the developer: "Requirements approved. Moving to solution analysis now."
+
+The Stop hook will automatically start `/solution-analysis`.

--- a/.claude/skills/solution-analysis.md
+++ b/.claude/skills/solution-analysis.md
@@ -1,0 +1,107 @@
+Design the implementation approach for the approved requirement before any code is written.
+
+This skill is part of the automated development workflow. It runs automatically after requirement-analysis completes, or can be invoked manually with `/solution-analysis`.
+
+## Steps
+
+### 1. Read current workflow state
+
+```
+node scripts/workflow-state.mjs get
+```
+
+The `requirement_text` field contains the approved requirements. If it is empty or `requirement_approved` is false, stop and tell the developer: "Requirements have not been approved yet. Please run `/requirement-analysis` first."
+
+If `loop_back_reason` is set, this is a loop-back from implementation. Acknowledge why: "I was sent back here from [loop_back_from] because [loop_back_reason]. I'll revise the solution with that in mind."
+
+### 2. Explore the codebase
+
+Read all files that will be touched by the change. Build a picture of:
+
+- The exact functions, composables, and components involved
+- How data flows through the affected code
+- What tests already cover this area
+- What the simplest correct change looks like
+
+Don't guess — read the actual files.
+
+### 3. Identify solution options
+
+Propose 1–3 concrete approaches. For each, describe:
+
+- What changes in which files
+- The main advantage (simpler, faster, more maintainable)
+- The main trade-off or risk
+
+If one option is clearly best, say so and explain why. Don't manufacture fake alternatives just to show options.
+
+### 4. Assess non-functional risks
+
+For each solution option under consideration, check the following areas and flag any concerns. For each concern raised, include a concrete mitigation as part of the solution design — not as a future consideration.
+
+**Reactivity and state correctness**
+- Does the change mutate arrays or objects in ways Vue's reactivity won't detect? (Direct index assignment, `delete`, spreading reactive objects)
+- Could destructuring a composable's return value lose reactivity?
+- Does the change introduce state that two composables or components could get out of sync?
+
+**Performance**
+- Does the change add reactive computations that will re-run on every keystroke or render cycle?
+- Are there loops, filters, or sorts inside computed properties or watchers that could be expensive on large task lists?
+- Does anything now run in a Vue template expression that should be a `computed`?
+
+**Persistence and data integrity**
+- Does the change affect localStorage keys, data shapes, or serialisation formats? If so, will existing stored data still load correctly, or does it need a migration?
+- Could the change silently discard a user's saved data if they have an older format?
+
+**Accessibility**
+- Does the change add or modify interactive elements? If so, are keyboard navigation and focus management preserved?
+- Are ARIA attributes, roles, or labels needed for new UI elements?
+- Does any new dynamic content need to be announced to screen readers?
+
+**Test stability**
+- Does the change introduce timing dependencies (setTimeout, async state, animations) that could make tests flaky?
+- Does it rely on order of operations or global state that tests reset differently?
+
+**Security**
+- Is any user-provided string rendered as HTML? If so, is it sanitised?
+- Is anything read from localStorage treated as trusted? Validate the shape before use.
+
+If any concern has no clear mitigation, raise it with the developer before proceeding. If a concern requires a requirement decision, loop back:
+
+```
+node scripts/workflow-state.mjs loop-back requirement-analysis "Non-functional risk identified that needs a requirement decision: [risk and options]"
+```
+
+### 5. Ask about unknowns
+
+If the solution has open questions the developer needs to decide — naming, UI behaviour, data model shape, whether an existing abstraction should be extended or replaced — ask now, not during implementation.
+
+Ask one question at a time. Stop when the solution is fully specified.
+
+If you discover that the requirements are incomplete or contradictory and that's blocking solution design, loop back:
+
+```
+node scripts/workflow-state.mjs loop-back requirement-analysis "Need clarification on [specific gap] before the solution can be designed"
+```
+
+Then tell the developer what's happening. The Stop hook will route back to `/requirement-analysis` automatically.
+
+### 6. Save the approved solution
+
+When the developer agrees on the approach, write a concise summary to state — including any non-functional risks and their mitigations:
+
+```
+node scripts/workflow-state.mjs set solution_text "APPROACH: <what will change>. FILES: <list>. RATIONALE: <why this approach>. DECISIONS: <any options that were decided>. NFR MITIGATIONS: <risks identified and how each is addressed, or 'none identified'>."
+```
+
+Then approve to trigger implementation automatically:
+
+```
+node scripts/workflow-state.mjs approve solution
+```
+
+### 7. Confirm to the developer
+
+Tell the developer: "Solution approved. Starting implementation now."
+
+The Stop hook will automatically start `/solution-implementation`.

--- a/.claude/skills/solution-implementation.md
+++ b/.claude/skills/solution-implementation.md
@@ -1,0 +1,63 @@
+Implement the approved solution as described by solution-analysis.
+
+This skill is part of the automated development workflow. It runs automatically after solution-analysis completes, or can be invoked manually with `/solution-implementation`.
+
+## Steps
+
+### 1. Read current workflow state
+
+```
+node scripts/workflow-state.mjs get
+```
+
+The `requirement_text` and `solution_text` fields are your spec. Both must be approved before proceeding. If either is missing or not approved, tell the developer and stop.
+
+### 2. Re-read every file you will touch
+
+Before writing a single line, read the full content of every file mentioned in `solution_text`. Understand the existing patterns — naming conventions, composable structure, component style, test setup. Match them exactly.
+
+### 3. Implement the change
+
+Work through the files in `solution_text` in a logical order (data layer first, then UI, then config). Make only the changes needed to deliver the approved requirement — no refactoring of surrounding code, no extra abstractions, no "while I'm here" cleanups.
+
+If you encounter something unexpected that makes the planned approach unworkable, **stop and loop back rather than improvising**. See step 4.
+
+If you spot a pre-existing bug (not introduced by your change), trigger `/report-bug` with source `development` before fixing it. After the issue is created and fixed, continue with the implementation.
+
+### 4. Loop back if blocked
+
+**If you need more information about the requirement:**
+
+```
+node scripts/workflow-state.mjs loop-back requirement-analysis "During implementation discovered [specific gap]: [details]"
+```
+
+Tell the developer what happened. The Stop hook will route back to `/requirement-analysis` automatically.
+
+**If the planned solution needs to change:**
+
+```
+node scripts/workflow-state.mjs loop-back solution-analysis "The planned approach won't work because [reason]. Need to redesign [aspect]."
+```
+
+Tell the developer what happened. The Stop hook will route back to `/solution-analysis` automatically.
+
+### 5. Save the implementation summary and advance
+
+When the implementation is complete, write a brief summary of what changed:
+
+```
+node scripts/workflow-state.mjs set implementation_summary "Changed [files]. Added [what]. Modified [what]. Removed [what]."
+```
+
+Queue implementation-analysis as the next step:
+
+```
+node scripts/workflow-state.mjs set pending_next_step "implementation-analysis"
+```
+
+### 6. Confirm to the developer
+
+Tell the developer: "Implementation complete. Moving to implementation analysis now."
+
+The Stop hook will automatically start `/implementation-analysis`.

--- a/.claude/skills/unit-test-analysis.md
+++ b/.claude/skills/unit-test-analysis.md
@@ -1,0 +1,69 @@
+Review unit tests for the completed change and update them as needed.
+
+This skill is part of the automated development workflow. It runs automatically after implementation-analysis completes, or can be invoked manually with `/unit-test-analysis`.
+
+## Steps
+
+### 1. Read current workflow state
+
+```
+node scripts/workflow-state.mjs get
+```
+
+`implementation_approved` must be true before proceeding.
+
+Determine the project root for running npm commands. In a worktree, `node_modules` lives in the main repo, not the worktree checkout:
+
+```
+git_dir=$(git rev-parse --git-dir)
+if [ -f "${git_dir}/commondir" ]; then
+  common=$(cat "${git_dir}/commondir")
+  project_root=$(cd "${git_dir}/${common}/.." && pwd)
+else
+  project_root=$(git rev-parse --show-toplevel)
+fi
+```
+
+### 2. Identify which unit tests are affected
+
+Read all files in `tests/unit/` and cross-reference with the git diff:
+
+```
+git diff main...HEAD --name-only
+```
+
+A unit test file needs to change when:
+- A composable has new or changed logic (filtering, state transitions, computed values, side effects)
+- A component has new conditional rendering, new props, or new emits
+
+Unit tests in this project always come in pairs under `tests/unit/<feature>/`:
+- `composable.test.js` — uses `vi.resetModules()` for fresh state isolation
+- `components.test.js` — uses `vi.mock(...)` to mock the composable entirely
+
+Read existing tests to understand naming and setup patterns before writing new ones. Match them exactly.
+
+### 3. Make the required changes
+
+Add, remove, or update tests to reflect the change. If no test changes are needed (the existing suite already covers the new behaviour), note this and skip to step 5.
+
+### 4. Run the affected tests
+
+Run only the test files that were changed or are directly related to the change:
+
+```
+cd $project_root && npm test -- --run --reporter=verbose <test-file-pattern>
+```
+
+If a test fails because of a real bug in the source (not a test setup issue), trigger `/report-bug` with source `unit-test` before fixing. Provide the test file, line, failure message, and what the test exercises. After the issue is created and the bug is fixed, re-run the tests to confirm they pass.
+
+### 5. Advance to e2e test analysis
+
+```
+node scripts/workflow-state.mjs approve unit-tests
+```
+
+### 6. Confirm to the developer
+
+Tell the developer: "Unit tests updated and passing. Moving to e2e test analysis now."
+
+The Stop hook will automatically start `/e2e-test-analysis`.

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ dist-ssr
 .claude/settings.local.json
 .claude/launch.json
 
+# Developer workflow runtime state (per-developer, not committed)
+.claude/workflow/
+
 # Playwright test artifacts
 test-results/
 playwright-report/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,44 +36,96 @@ E2E tests in `tests/e2e/` clear `localStorage` and reload before every test so t
 
 ## Bug tracking
 
-Bugs are tracked as GitHub issues whenever they are identified, regardless of the process that found them. Every issue records which process detected the bug — both in the issue body (`**Detected by:**`) and as a GitHub label (`found:development`, `found:qa`, `found:ci`, or `found:manual`) so issues can be filtered by detection process.
+Bugs are tracked as GitHub issues whenever they are identified, regardless of where they're found. Every issue records which process detected it — in the issue body (`**Detected by:**`) and as a GitHub label — so issues can be filtered by detection process.
 
-| Process | Source value | How issues are created | How issues are closed |
+In all cases, run `/report-bug` to log an issue. When triggered by a workflow skill it happens automatically; when you find a bug manually, run it yourself.
+
+| Where the bug was found | Source value | How issues are created | How issues are closed |
 |---|---|---|---|
-| Development | `development` | Create before fixing with `--source development` (see below) | Include `Fixes #N` in the commit message |
-| QA review (`/qa-review`) | `qa-review` | Created for each bug found, before fixing | Closed with root cause + fix details after the fix |
-| Unit / E2E test failures (during QA) | `unit-test` / `e2e-test` | Created when a test fails due to a source bug | Closed after the source fix is applied |
-| CI pipeline | `ci-unit-tests` / `ci-e2e-tests` | Created automatically on any test job failure | Include `Fixes #N` in a commit message |
-| Manual report | `manual` | Run `/report-bug` and describe what you saw | Include `Fixes #N` in a commit message |
-
-**Reporting a development-time bug**: if you spot a bug in existing code while implementing a feature (before the QA step), create an issue before fixing it:
-
-```
-node scripts/bug-tracker.mjs create \
-  --title "Bug: <concise description>" \
-  --body "<what the bug is, which file and line, how it manifests>" \
-  --source "development"
-```
-
-Then fix the bug and include `Fixes #N` in the commit message to close the issue automatically.
+| During code writing (`/solution-implementation`) | `development` | `/report-bug` triggered automatically | Closed by `/report-bug` after fix |
+| During code review (`/implementation-analysis`) | `qa-review` | `/report-bug` triggered automatically | Closed by `/report-bug` after fix |
+| Unit test failure (`/unit-test-analysis`) | `unit-test` | `/report-bug` triggered automatically | Closed by `/report-bug` after fix |
+| E2E test failure (`/e2e-test-analysis`) | `e2e-test` | `/report-bug` triggered automatically | Closed by `/report-bug` after fix |
+| CI unit test failure (`/deploy-branch`, `/deploy-main`) | `ci-unit-tests` | `/report-bug` triggered automatically | Closed by `/report-bug` after fix |
+| CI e2e test failure (`/deploy-branch`, `/deploy-main`) | `ci-e2e-tests` | `/report-bug` triggered automatically | Closed by `/report-bug` after fix |
+| Developer finds a bug at any point | `manual` | Run `/report-bug` and describe what you saw | Closed by `/report-bug` after fix, or via `Fixes #N` in a commit |
 
 **Auto-close via commit message**: any commit whose message contains `Fixes #N`, `Closes #N`, or `Resolves #N` triggers the `post-commit` hook, which comments on the issue with the fix summary and closes it.
 
 The core script is `scripts/bug-tracker.mjs` — it handles deduplication (won't create a second issue if one with the same title is already open).
 
+## Developer workflow
+
+Every code change — whether made with Claude or manually — follows a structured pipeline. The skills are stored in `.claude/skills/` and available to all developers who clone the repo.
+
+### With Claude (automated)
+
+When you send Claude a message asking for a code change, the workflow starts automatically. Each step chains to the next without needing manual commands:
+
+| Step | Skill | What it does |
+|---|---|---|
+| 1 | `/requirement-analysis` | Captures and validates requirements; asks clarifying questions |
+| 2 | `/solution-analysis` | Designs the implementation approach; explores the codebase |
+| 3 | `/solution-implementation` | Writes the code |
+| 4 | `/implementation-analysis` | Verifies the code matches the requirement and solution |
+| 5 | `/unit-test-analysis` | Updates unit tests and runs affected tests |
+| 6 | `/e2e-test-analysis` | Updates e2e tests and runs affected tests |
+| 7 | `/document-analysis` | Updates docs, then asks about deployment path |
+| 8a | `/deploy-branch` | Deploys to a branch for manual testing |
+| 8b | `/deploy-main` | Runs full CI and merges to main |
+
+Each skill can also be run manually at any time by typing `/skill-name`.
+
+**Loop-backs**: if implementation or analysis discovers a gap, the workflow automatically routes back to an earlier step with full context, then resumes forward from there.
+
+**Resuming an interrupted workflow**: if a session is interrupted mid-workflow, the next Claude session detects the active state and offers to resume from where it left off.
+
+**Resetting the workflow**: if you want to start fresh:
+```
+node scripts/workflow-state.mjs reset
+```
+
+### Without Claude (manual)
+
+Run each step yourself and use these commands to advance the workflow:
+
+```
+node scripts/workflow-state.mjs start               # begin a new workflow
+node scripts/workflow-state.mjs set requirement_text "..."
+node scripts/workflow-state.mjs approve requirement  # advance to solution-analysis
+node scripts/workflow-state.mjs set solution_text "..."
+node scripts/workflow-state.mjs approve solution     # advance to solution-implementation
+node scripts/workflow-state.mjs set implementation_summary "..."
+node scripts/workflow-state.mjs set pending_next_step "implementation-analysis"
+node scripts/workflow-state.mjs approve implementation  # advance to unit-test-analysis
+node scripts/workflow-state.mjs approve unit-tests   # advance to e2e-test-analysis
+node scripts/workflow-state.mjs approve e2e-tests    # advance to document-analysis
+node scripts/workflow-state.mjs approve docs         # advance to deploy
+node scripts/workflow-state.mjs reset                # clear state after deploy
+```
+
+Check current state at any time:
+```
+node scripts/workflow-state.mjs get
+```
+
 ## QA review and pull requests
 
-Before pushing a branch or creating a PR, QA review must pass. Run:
+A QA approval marker must exist before pushing a branch or creating a PR. How it gets written depends on which workflow path you're on:
+
+**Automated workflow** (`/requirement-analysis` → … → `/deploy-main`): the marker is written automatically by `/deploy-main` after all CI checks pass. You do not need to run `/qa-review` separately.
+
+**Manual workflow** (code written outside the automated pipeline): run `/qa-review` before pushing.
 
 ```
 /qa-review
 ```
 
-This skill reviews all changed code for logic issues, inefficiency, and maintainability problems; fixes what it finds; checks whether unit and e2e tests are needed and writes them if so; and updates README/CLAUDE.md if the change affects documented behaviour. When everything is clean it writes a QA approval marker for the current branch and commit.
+This reviews all changed code for logic issues, inefficiency, and maintainability problems; fixes what it finds; checks whether unit and e2e tests are needed and writes them if so; and updates README/CLAUDE.md if the change affects documented behaviour. When everything is clean it writes the QA approval marker.
 
-The `pre-push` git hook and the Claude Code `PreToolUse` hook both enforce this — pushing or running `gh pr create` will be blocked if the marker is missing or stale (i.e. new commits were added after the last review).
+To re-approve after adding commits, run `/qa-review` again.
 
-To re-approve after adding commits, just run `/qa-review` again.
+The `pre-push` git hook and the Claude Code `PreToolUse` hook both enforce the marker — pushing or running `gh pr create` will be blocked if it is missing or stale.
 
 **Working without Claude Code?** Run the manual equivalent instead:
 

--- a/scripts/workflow-state.mjs
+++ b/scripts/workflow-state.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { execSync } from 'child_process';
+import { join, dirname } from 'path';
+
+function getRepoRoot() {
+  return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+}
+
+const STATE_PATH = join(getRepoRoot(), '.claude', 'workflow', 'state.json');
+const STATE_DIR = dirname(STATE_PATH);
+
+function readState() {
+  if (!existsSync(STATE_PATH)) return null;
+  try {
+    return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeState(state) {
+  mkdirSync(STATE_DIR, { recursive: true });
+  state.last_updated = new Date().toISOString();
+  writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+}
+
+const NEXT_STEP = {
+  'requirement':    'solution-analysis',
+  'solution':       'solution-implementation',
+  'implementation': 'implementation-analysis',
+  'unit-tests':     'e2e-test-analysis',
+  'e2e-tests':      'document-analysis',
+  'docs':           'deploy',
+};
+
+const cmd = process.argv[2];
+
+if (cmd === 'get') {
+  console.log(JSON.stringify(readState(), null, 2));
+
+} else if (cmd === 'start') {
+  const reqText = process.argv.slice(3).join(' ') || null;
+  writeState({
+    active: true,
+    current_step: 'requirement-analysis',
+    requirement_text: reqText,
+    requirement_approved: false,
+    solution_text: null,
+    solution_approved: false,
+    implementation_summary: null,
+    implementation_approved: false,
+    unit_tests_done: false,
+    e2e_tests_done: false,
+    docs_done: false,
+    pending_next_step: null,
+    loop_back_from: null,
+    loop_back_reason: null,
+    started_at: new Date().toISOString(),
+  });
+  console.log('Workflow started.');
+
+} else if (cmd === 'approve') {
+  const step = process.argv[3];
+  const state = readState() || { active: true };
+  const flagMap = {
+    'requirement':    () => { state.requirement_approved = true; },
+    'solution':       () => { state.solution_approved = true; },
+    'implementation': () => { state.implementation_approved = true; },
+    'unit-tests':     () => { state.unit_tests_done = true; },
+    'e2e-tests':      () => { state.e2e_tests_done = true; },
+    'docs':           () => { state.docs_done = true; },
+  };
+  if (!flagMap[step]) {
+    console.error(`Unknown step: ${step}. Valid: ${Object.keys(flagMap).join(', ')}`);
+    process.exit(1);
+  }
+  flagMap[step]();
+  state.pending_next_step = NEXT_STEP[step];
+  writeState(state);
+  console.log(`Approved: ${step}. Queued next step: ${NEXT_STEP[step]}`);
+
+} else if (cmd === 'set') {
+  const key = process.argv[3];
+  const value = process.argv.slice(4).join(' ');
+  const state = readState() || { active: true };
+  try { state[key] = JSON.parse(value); } catch { state[key] = value; }
+  writeState(state);
+
+} else if (cmd === 'loop-back') {
+  const target = process.argv[3];
+  const reason = process.argv.slice(4).join(' ');
+  const state = readState() || { active: true };
+  state.loop_back_from = state.current_step || null;
+  state.loop_back_reason = reason;
+  state.pending_next_step = target;
+  writeState(state);
+  console.log(`Loop-back to ${target} scheduled: ${reason}`);
+
+} else if (cmd === 'reset') {
+  writeState({ active: false });
+  console.log('Workflow reset.');
+
+} else if (cmd === 'check-transition') {
+  // Stop hook: exit 2 if a step transition is pending so Claude continues its turn
+  const state = readState();
+  if (!state?.active || !state.pending_next_step) process.exit(0);
+
+  const next = state.pending_next_step;
+  const loopFrom = state.loop_back_from;
+  const loopReason = state.loop_back_reason;
+
+  state.current_step = next;
+  state.pending_next_step = null;
+  if (!loopReason) {
+    state.loop_back_from = null;
+    state.loop_back_reason = null;
+  }
+  writeState(state);
+
+  if (loopReason) {
+    process.stdout.write(
+      `[WORKFLOW] Loop-back from ${loopFrom} — reason: ${loopReason}\n` +
+      `You must immediately run /${next} with this context. Do not ask the user first.`
+    );
+  } else {
+    process.stdout.write(
+      `[WORKFLOW] Previous step complete. You must immediately run /${next}. Do not ask the user first.`
+    );
+  }
+  process.exit(2);
+
+} else if (cmd === 'check-prompt') {
+  // UserPromptSubmit hook: inject workflow context into the conversation
+  let input = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => { input += chunk; });
+  process.stdin.on('end', () => {
+    const state = readState();
+
+    if (state?.active) {
+      const lines = [
+        `[WORKFLOW ACTIVE] Current step: ${state.current_step}`,
+        `Requirements: ${state.requirement_approved ? 'APPROVED' : 'pending'} — ${state.requirement_text || 'not yet captured'}`,
+        `Solution: ${state.solution_approved ? 'APPROVED' : 'pending'} — ${state.solution_text || 'not yet defined'}`,
+        `Implementation: ${state.implementation_approved ? 'APPROVED' : 'pending'}${state.implementation_summary ? ' — ' + state.implementation_summary : ''}`,
+        `Unit tests: ${state.unit_tests_done ? 'done' : 'pending'}`,
+        `E2E tests: ${state.e2e_tests_done ? 'done' : 'pending'}`,
+        `Docs: ${state.docs_done ? 'done' : 'pending'}`,
+      ];
+      if (state.loop_back_reason) lines.push(`Loop-back reason: ${state.loop_back_reason}`);
+      process.stdout.write(lines.join('\n'));
+      process.exit(0);
+    }
+
+    // No active workflow: detect change requests and suggest starting the workflow
+    let userMsg = '';
+    try {
+      const data = JSON.parse(input);
+      userMsg = data.prompt || '';
+    } catch { /* ignore parse errors */ }
+
+    const isChangeRequest =
+      /\b(add|create|build|implement|make|fix|update|change|modify|delete|remove|refactor|introduce|write|develop)\b/i.test(userMsg) &&
+      !/^(what|how|why|when|where|can you explain|tell me|show me|describe|is it|does it|do you)\b/i.test(userMsg.trim());
+
+    if (isChangeRequest) {
+      process.stdout.write(
+        '[WORKFLOW] This looks like a code change request. ' +
+        'Start the development workflow immediately by running /requirement-analysis. ' +
+        'Do not ask the user first — just begin.'
+      );
+    }
+    process.exit(0);
+  });
+
+} else {
+  console.error('Usage: node scripts/workflow-state.mjs <get|start|approve|set|loop-back|reset|check-transition|check-prompt>');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Adds a nine-step development workflow stored in `.claude/skills/` — available to every developer who clones the repo
- When using Claude Code, the workflow auto-triggers on change requests and chains steps automatically via `Stop` and `UserPromptSubmit` hooks in `.claude/settings.json`
- `scripts/workflow-state.mjs` manages per-session state and drives the hook transitions
- `/report-bug` updated to be a unified bug-reporting entry point for all workflow skills and manual use
- `CLAUDE.md` updated to document the workflow and clarify that `/qa-review` is only needed on the manual path

## Workflow steps

| Step | Skill | Trigger |
|---|---|---|
| 1 | `/requirement-analysis` | Auto-detected change request, or manual |
| 2 | `/solution-analysis` | Auto after requirements approved |
| 3 | `/solution-implementation` | Auto after solution approved |
| 4 | `/implementation-analysis` | Auto after implementation complete |
| 5 | `/unit-test-analysis` | Auto after implementation approved |
| 6 | `/e2e-test-analysis` | Auto after unit tests done |
| 7 | `/document-analysis` | Auto after e2e tests done |
| 8a | `/deploy-branch` | Developer chooses manual testing |
| 8b | `/deploy-main` | Developer chooses direct deploy |

Loop-backs are fully automatic — if implementation or analysis finds a gap, the workflow routes back to an earlier step with full context and resumes forward.

## Test plan

- [ ] Clone a fresh copy of the repo and verify all skill files are present under `.claude/skills/`
- [ ] Verify `.claude/settings.json` is present and contains `Stop` and `UserPromptSubmit` hooks
- [ ] Send a change request to Claude and confirm `/requirement-analysis` starts automatically
- [ ] Step through the workflow and confirm each step auto-chains to the next
- [ ] Run `/report-bug` manually and confirm it creates a GitHub issue with source `manual`
- [ ] Verify `node scripts/workflow-state.mjs get` returns `null` on a fresh clone (no state file)
- [ ] Confirm `.claude/workflow/` is gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)