### PR TITLE
Add /post-deploy-report skill to workflow

### DIFF
--- a/.claude/skills/deploy-main.md
+++ b/.claude/skills/deploy-main.md
@@ -110,11 +110,18 @@ gh pr merge <PR-number> --squash --delete-branch
 node scripts/workflow-state.mjs reset
 ```
 
-### 7. Report to the developer
+### 7. Generate the post-deploy report
+
+Run `/post-deploy-report` passing the PR number from step 5. This generates a markdown report in `reports/` and commits it to main.
+
+If report generation fails for any reason, log a warning to the developer but do not treat it as a deploy failure — the merge has already completed successfully.
+
+### 8. Report to the developer
 
 Tell the developer:
 - The PR number and that it has been merged to main
 - The source branch has been deleted
+- The report filename that was committed to `reports/`
 - The full workflow is complete
 
 If the wiki auto-update workflow is running, mention that it will update the GitHub wiki automatically.

--- a/.claude/skills/post-deploy-report.md
+++ b/.claude/skills/post-deploy-report.md
@@ -1,0 +1,121 @@
+Generate a post-deployment report for the change that was just merged to main.
+
+This skill is part of the automated development workflow. It runs automatically at the end of `/deploy-main`, or can be invoked manually with `/post-deploy-report <PR-number>`.
+
+## Steps
+
+### 1. Gather workflow state and inputs
+
+Read the current workflow state (may already be reset — that is fine, use what is available):
+
+```
+node scripts/workflow-state.mjs get
+```
+
+The PR number must be provided — either passed as an argument or taken from the deploy-main context. If it is not available, ask the developer for it before continuing.
+
+Determine the project root (handles worktrees):
+
+```
+git_dir=$(git rev-parse --git-dir)
+if [ -f "${git_dir}/commondir" ]; then
+  common=$(cat "${git_dir}/commondir")
+  project_root=$(cd "${git_dir}/${common}/.." && pwd)
+else
+  project_root=$(git rev-parse --show-toplevel)
+fi
+```
+
+### 2. Fetch PR details from GitHub
+
+```
+gh pr view <PR-number> --json number,title,url,mergedAt,mergeCommit,body,author
+```
+
+Also fetch the list of commits on the PR to find `Fixes #N` / `Closes #N` / `Resolves #N` references:
+
+```
+gh pr view <PR-number> --json commits --jq '.commits[].messageHeadline'
+```
+
+Extract all issue numbers referenced in commit messages and the PR body using the patterns `Fixes #N`, `Closes #N`, `Resolves #N`.
+
+### 3. Fetch bug issues linked to this change
+
+Fetch details for each referenced issue number:
+
+```
+gh issue view <N> --json number,title,state,labels,body,closedAt
+```
+
+Also search for any open or recently closed issues whose labels include `found:development`, `found:qa`, `found:ci`, or `found:manual`, cross-referenced against the PR merge date to catch issues that were raised and closed during this workflow but not referenced via `Fixes #N`:
+
+```
+gh issue list --state closed --label bug --json number,title,labels,body,closedAt \
+  --jq '[.[] | select(.closedAt >= "<merge-date-minus-7-days>")]'
+```
+
+Read the `**Detected by:**` field in each issue body to determine which workflow stage found it.
+
+### 4. Write the report
+
+Determine the report filename:
+- Date: the PR merge date in `YYYY-MM-DD` format
+- Slug: PR title lowercased, non-alphanumeric characters replaced with hyphens, truncated to 40 characters, trailing hyphens removed
+
+```
+reports/YYYY-MM-DD-pr-<N>-<slug>.md
+```
+
+Write the report with this structure:
+
+```markdown
+# Change report: <PR title>
+
+**PR**: [#N](<PR URL>) · **Merged**: <merge date> · **Commit**: [`<short SHA>`](<commit URL>)
+
+## What changed
+
+<2–4 sentences drawn from the requirement_text and implementation_summary: what the change does and what files it touched.>
+
+## Why
+
+<1–2 sentences drawn from the requirement_text GOAL field: the problem this change solves.>
+
+## Bug analysis
+
+<If no bugs were raised:>
+No bugs were raised during this change.
+
+<If bugs were raised:>
+**N bug(s) raised** across this change.
+
+| # | Title | Detected at | Status |
+|---|---|---|---|
+| [#N](<issue URL>) | <title> | <stage> | Fixed before merge / Fixed after merge / Open |
+
+**Analysis**: <2–4 sentences of genuine analysis — not just a restatement of the table. Cover: which stages bugs were caught at and what that implies about the process (e.g. "Both bugs were caught during manual testing rather than automated checks, suggesting the automated suite does not cover visual layout at mobile viewports."); whether any bugs slipped later than expected; any pattern in bug type (visual, logic, performance, etc.); and a one-sentence verdict on the quality signal this change sends.>
+```
+
+### 5. Commit the report to main
+
+Fetch the latest main first, then commit the report file directly:
+
+```
+cd $project_root && git fetch origin main
+git checkout main -- . 2>/dev/null || true
+git add reports/<filename>.md
+git commit -m "Add post-deploy report for PR #<N>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git push origin main
+```
+
+If the commit or push fails (e.g. a conflict or permissions issue), save the report content and tell the developer: "Report generated but could not be committed automatically. Here is the content — save it to `reports/<filename>.md` and commit manually."
+
+### 6. Confirm to the developer
+
+Tell the developer:
+- The report filename and that it has been committed to main
+- A one-line summary of the bug analysis verdict
+- That past reports can be found in the `reports/` directory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ When you send Claude a message asking for a code change, the workflow starts aut
 | 7 | `/document-analysis` | Updates docs, then asks about deployment path |
 | 8a | `/deploy-branch` | Deploys to a branch for manual testing |
 | 8b | `/deploy-main` | Runs full CI and merges to main |
+| 9 | `/post-deploy-report` | Generates a change report (summary + bug analysis) and commits it to `reports/` |
 
 Each skill can also be run manually at any time by typing `/skill-name`.
 
@@ -154,3 +155,4 @@ For direct pushes to main, run `/wiki-update` in Claude Code to trigger the same
 | `src/components/TaskColumn.vue` | Column with add-task form and drop zone |
 | `tests/e2e/helpers.js` | Shared Playwright helpers (`addTask`, `taskCard`, `openEdit`) |
 | `scripts/bug-tracker.mjs` | CLI for creating and closing GitHub bug issues |
+| `reports/` | Post-deploy change reports, one markdown file per merged PR |


### PR DESCRIPTION
## Summary
- New `/post-deploy-report` skill generates a markdown change report after each merge, stored in `reports/YYYY-MM-DD-pr-N-slug.md` and committed to main
- Report covers: change summary (from workflow state + GitHub PR details), and an analytical bug section identifying detection stages, patterns, and a verdict
- Triggered automatically as the final step of `/deploy-main`; can also be run manually
- `deploy-main.md` updated with new step 7 (generate report) and renumbered step 8 (confirm to developer)
- `CLAUDE.md` workflow table updated with step 9, and `reports/` added to key files

## Test plan
- [x] Build passes
- [x] Unit tests passing (247/247)
- [x] No e2e spec files changed — run skipped per workflow
- [x] Skills-only change; no source code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)