### PR TITLE
Block workflow auto-advance when a question is awaiting an answer

### DIFF
--- a/.claude/skills/document-analysis.md
+++ b/.claude/skills/document-analysis.md
@@ -43,15 +43,27 @@ Give the developer a concise summary of everything done in this workflow:
 - Test results (unit + e2e)
 - Doc updates made (or "none needed")
 
+Register the question so the workflow is blocked until the developer answers:
+
+```
+node scripts/workflow-state.mjs await-input "Deploy to a branch for manual testing first, or directly to main?"
+```
+
 Then ask:
 
 > "Everything is complete. Would you like to:
 > - **Test manually first** — I'll deploy the changes to a branch so you can verify in a browser before merging
 > - **Deploy directly to main** — I'll run the full CI pipeline and merge straight to main"
 
-Wait for their response before advancing. Do not set a next step automatically here.
+End your turn. Do not continue until the developer responds.
 
 ### 5. Route to the chosen deployment path
+
+When the developer answers, first clear the awaiting state:
+
+```
+node scripts/workflow-state.mjs clear-awaiting
+```
 
 If the developer wants to test manually:
 ```

--- a/.claude/skills/requirement-analysis.md
+++ b/.claude/skills/requirement-analysis.md
@@ -33,7 +33,21 @@ Ask the developer what they want to change or build. Keep asking until you have 
 
 Ask one focused question at a time. Don't ask for everything at once.
 
-If the developer's initial message already answers most of these, confirm your understanding rather than re-asking. For example: "I understand you want to [X], which should [Y], and it's done when [Z]. Is that right?"
+Before asking each question, register it so the workflow is blocked until the developer answers:
+
+```
+node scripts/workflow-state.mjs await-input "<the question you are about to ask>"
+```
+
+Then ask the question and end your turn. Do not continue until the developer responds. When the answer arrives, call:
+
+```
+node scripts/workflow-state.mjs clear-awaiting
+```
+
+Then either ask the next question (repeating the await-input pattern) or proceed to step 3 if you have everything you need.
+
+If the developer's initial message already answers most of these, confirm your understanding rather than re-asking. For example: "I understand you want to [X], which should [Y], and it's done when [Z]. Is that right?" Register this confirmation as an await-input, then end your turn.
 
 ### 3. Log a bug issue if the requirement is a bug fix
 

--- a/.claude/skills/solution-analysis.md
+++ b/.claude/skills/solution-analysis.md
@@ -76,7 +76,19 @@ node scripts/workflow-state.mjs loop-back requirement-analysis "Non-functional r
 
 If the solution has open questions the developer needs to decide — naming, UI behaviour, data model shape, whether an existing abstraction should be extended or replaced — ask now, not during implementation.
 
-Ask one question at a time. Stop when the solution is fully specified.
+Before asking each question, register it so the workflow is blocked until the developer answers:
+
+```
+node scripts/workflow-state.mjs await-input "<the question you are about to ask>"
+```
+
+Then ask the question and end your turn. Do not continue until the developer responds. When the answer arrives, call:
+
+```
+node scripts/workflow-state.mjs clear-awaiting
+```
+
+Then either ask the next question (repeating the await-input pattern) or proceed to step 6 if the solution is fully specified.
 
 If you discover that the requirements are incomplete or contradictory and that's blocking solution design, loop back:
 

--- a/scripts/workflow-state.mjs
+++ b/scripts/workflow-state.mjs
@@ -53,6 +53,7 @@ if (cmd === 'get') {
     unit_tests_done: false,
     e2e_tests_done: false,
     docs_done: false,
+    awaiting_input: null,
     pending_next_step: null,
     loop_back_from: null,
     loop_back_reason: null,
@@ -76,6 +77,7 @@ if (cmd === 'get') {
     process.exit(1);
   }
   flagMap[step]();
+  state.awaiting_input = null;
   state.pending_next_step = NEXT_STEP[step];
   writeState(state);
   console.log(`Approved: ${step}. Queued next step: ${NEXT_STEP[step]}`);
@@ -86,6 +88,19 @@ if (cmd === 'get') {
   const state = readState() || { active: true };
   try { state[key] = JSON.parse(value); } catch { state[key] = value; }
   writeState(state);
+
+} else if (cmd === 'await-input') {
+  const question = process.argv.slice(3).join(' ');
+  const state = readState() || { active: true };
+  state.awaiting_input = question || true;
+  writeState(state);
+  console.log('Workflow paused — awaiting developer input.');
+
+} else if (cmd === 'clear-awaiting') {
+  const state = readState() || { active: true };
+  state.awaiting_input = null;
+  writeState(state);
+  console.log('Awaiting-input cleared.');
 
 } else if (cmd === 'loop-back') {
   const target = process.argv[3];
@@ -105,6 +120,7 @@ if (cmd === 'get') {
   // Stop hook: exit 2 if a step transition is pending so Claude continues its turn
   const state = readState();
   if (!state?.active || !state.pending_next_step) process.exit(0);
+  if (state.awaiting_input) process.exit(0); // blocked waiting for developer answer
 
   const next = state.pending_next_step;
   const loopFrom = state.loop_back_from;
@@ -149,6 +165,11 @@ if (cmd === 'get') {
         `Docs: ${state.docs_done ? 'done' : 'pending'}`,
       ];
       if (state.loop_back_reason) lines.push(`Loop-back reason: ${state.loop_back_reason}`);
+      if (state.awaiting_input && state.awaiting_input !== true) {
+        lines.push(`Awaiting your answer to: ${state.awaiting_input}`);
+      } else if (state.awaiting_input) {
+        lines.push(`Awaiting your answer to the last question asked.`);
+      }
       process.stdout.write(lines.join('\n'));
       process.exit(0);
     }
@@ -175,6 +196,6 @@ if (cmd === 'get') {
   });
 
 } else {
-  console.error('Usage: node scripts/workflow-state.mjs <get|start|approve|set|loop-back|reset|check-transition|check-prompt>');
+  console.error('Usage: node scripts/workflow-state.mjs <get|start|approve|set|await-input|clear-awaiting|loop-back|reset|check-transition|check-prompt>');
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Root cause: `approve docs` sets `pending_next_step`, so the stop hook advanced past the deploy-path question before the developer could answer
- Adds `awaiting_input` field to workflow state with two new commands: `await-input "question"` and `clear-awaiting`
- `check-transition` (stop hook) exits 0 — no advance — whenever `awaiting_input` is set
- `check-prompt` (UserPromptSubmit hook) surfaces the pending question in context so Claude re-asks it on resume
- `approve` always clears `awaiting_input` automatically
- Updated `requirement-analysis`, `solution-analysis`, and `document-analysis` skills to register blocking questions with `await-input` before asking and `clear-awaiting` when the answer arrives

## Test plan
- [x] Build passes
- [x] Unit tests passing (247/247)
- [x] Verified `check-transition` exits 0 when `awaiting_input` set, exits 2 after `clear-awaiting` + `approve`
- [x] Verified `approve` clears `awaiting_input` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)