### PR TITLE
Add cycle time to post-deploy report

### DIFF
--- a/.claude/skills/deploy-main.md
+++ b/.claude/skills/deploy-main.md
@@ -104,17 +104,17 @@ Get the PR number from the output, then merge:
 gh pr merge <PR-number> --squash --delete-branch
 ```
 
-### 6. Reset workflow state
+### 6. Generate the post-deploy report
+
+Run `/post-deploy-report` passing the PR number from step 5. This generates a markdown report in `reports/` and commits it to main. The report reads `started_at` from current workflow state to compute cycle time, so it must run before the state is reset.
+
+If report generation fails for any reason, log a warning to the developer but do not treat it as a deploy failure — the merge has already completed successfully.
+
+### 7. Reset workflow state
 
 ```
 node scripts/workflow-state.mjs reset
 ```
-
-### 7. Generate the post-deploy report
-
-Run `/post-deploy-report` passing the PR number from step 5. This generates a markdown report in `reports/` and commits it to main.
-
-If report generation fails for any reason, log a warning to the developer but do not treat it as a deploy failure — the merge has already completed successfully.
 
 ### 8. Report to the developer
 

--- a/.claude/skills/post-deploy-report.md
+++ b/.claude/skills/post-deploy-report.md
@@ -12,6 +12,8 @@ Read the current workflow state (may already be reset — that is fine, use what
 node scripts/workflow-state.mjs get
 ```
 
+Note the `started_at` field — this is when the requirement was first captured. If the workflow was reset before this skill ran, `started_at` may be absent; in that case the cycle time will be omitted from the report.
+
 The PR number must be provided — either passed as an argument or taken from the deploy-main context. If it is not available, ask the developer for it before continuing.
 
 Determine the project root (handles worktrees):
@@ -31,6 +33,13 @@ fi
 ```
 gh pr view <PR-number> --json number,title,url,mergedAt,mergeCommit,body,author
 ```
+
+Compute the cycle time using `started_at` (from workflow state) and `mergedAt` (from the PR). Format it as:
+- `Xm` if under 1 hour (e.g. `42m`)
+- `Xh Ym` if under 24 hours (e.g. `2h 7m`)
+- `Xd Yh` if 1 day or more (e.g. `1d 3h`)
+
+If `started_at` is absent, set cycle time to `null` and omit it from the report.
 
 Also fetch the list of commits on the PR to find `Fixes #N` / `Closes #N` / `Resolves #N` references:
 
@@ -72,7 +81,7 @@ Write the report with this structure:
 ```markdown
 # Change report: <PR title>
 
-**PR**: [#N](<PR URL>) · **Merged**: <merge date> · **Commit**: [`<short SHA>`](<commit URL>)
+**PR**: [#N](<PR URL>) · **Merged**: <merge date> · **Commit**: [`<short SHA>`](<commit URL>) · **Cycle time**: <cycle time (omit this field entirely if started_at was absent)>
 
 ## What changed
 


### PR DESCRIPTION
## Summary
- `post-deploy-report` now shows **Cycle time** in the report header — the elapsed time from when the requirement was first captured (`started_at` in workflow state) to when the PR was merged (`mergedAt` from GitHub)
- Duration is formatted as `Xm` / `Xh Ym` / `Xd Yh` depending on magnitude; omitted entirely if `started_at` is absent (e.g. manual invocation after a reset)
- `deploy-main` steps 6 and 7 are swapped so the report runs **before** `workflow-state.mjs reset` — otherwise `started_at` was wiped before the report could read it

## Test plan
- [ ] Run a full workflow end-to-end and verify the report header includes `· **Cycle time**: Xh Ym`
- [ ] Manually invoke `/post-deploy-report <N>` after resetting workflow state and verify the Cycle time field is absent (not `null` or blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)