### PR TITLE
Move settings cog to rightmost position in desktop header

### DIFF
--- a/.claude/skills/deploy-branch.md
+++ b/.claude/skills/deploy-branch.md
@@ -81,7 +81,7 @@ git branch --show-current
 
 Tell the developer:
 - The branch name and that it's been pushed
-- How to access this version locally: `git checkout <branch>` then `npm run dev` (or provide a preview URL if one is generated)
+- How to access this version locally: `git checkout <branch>` then `$env:PORT="5174"; npm run dev` — using port 5174 keeps it separate from the main branch server on 5173
 - All CI checks passed
 
 Then ask:

--- a/.claude/skills/deploy-branch.md
+++ b/.claude/skills/deploy-branch.md
@@ -81,7 +81,7 @@ git branch --show-current
 
 Tell the developer:
 - The branch name and that it's been pushed
-- How to access this version locally: `git checkout <branch>` then `npm run dev -- --port 5174` — using port 5174 keeps it separate from the main branch server on 5173
+- How to access this version locally: the worktree is already checked out at `.claude/worktrees/<worktree-name>`. Run `npm run dev` from there — `vite.config.js` auto-detects the worktree and serves on port 5174, leaving the main server on 5173 undisturbed. Navigate to `http://localhost:5174` to test
 - All CI checks passed
 
 Then ask:

--- a/.claude/skills/deploy-branch.md
+++ b/.claude/skills/deploy-branch.md
@@ -81,7 +81,7 @@ git branch --show-current
 
 Tell the developer:
 - The branch name and that it's been pushed
-- How to access this version locally: `git checkout <branch>` then `$env:PORT="5174"; npm run dev` — using port 5174 keeps it separate from the main branch server on 5173
+- How to access this version locally: `git checkout <branch>` then `npm run dev -- --port 5174` — using port 5174 keeps it separate from the main branch server on 5173
 - All CI checks passed
 
 Then ask:

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,6 +12,6 @@ export default defineConfig({
   webServer: {
     command: `npm run dev -- --port ${port}`,
     url: `http://localhost:${port}`,
-    reuseExistingServer: false,
+    reuseExistingServer: !process.env.CI,
   },
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -42,17 +42,17 @@ function handleToughLove() { dismissEncouragement(); showToughLove() }
             <span class="streak-text">{{ streakCount }} {{ streakCount === 1 ? 'day' : 'days' }}</span>
           </div>
           <button class="history-btn" @click="showHistory = true">History</button>
-          <button class="settings-btn" @click="showSettings = true" aria-label="Open settings">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <path d="M8 10a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z" stroke="currentColor" stroke-width="1.5"/>
-              <path d="M13.3 9.6a1 1 0 0 0 .2 1.1l.04.04a1.2 1.2 0 0 1-1.7 1.7l-.04-.04a1 1 0 0 0-1.1-.2 1 1 0 0 0-.6.92v.12a1.2 1.2 0 0 1-2.4 0v-.06a1 1 0 0 0-.66-.92 1 1 0 0 0-1.1.2l-.04.04a1.2 1.2 0 0 1-1.7-1.7l.04-.04a1 1 0 0 0 .2-1.1 1 1 0 0 0-.92-.6H3.2a1.2 1.2 0 0 1 0-2.4h.06a1 1 0 0 0 .92-.66 1 1 0 0 0-.2-1.1l-.04-.04a1.2 1.2 0 0 1 1.7-1.7l.04.04a1 1 0 0 0 1.1.2h.05A1 1 0 0 0 7.4 3.2V3.1a1.2 1.2 0 0 1 2.4 0v.06a1 1 0 0 0 .6.92 1 1 0 0 0 1.1-.2l.04-.04a1.2 1.2 0 0 1 1.7 1.7l-.04.04a1 1 0 0 0-.2 1.1v.05a1 1 0 0 0 .92.6h.12a1.2 1.2 0 0 1 0 2.4h-.06a1 1 0 0 0-.92.6Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </button>
         </div>
         <div class="controls-actions">
           <button class="encourage-btn" @click="handleEncourage">Encourage Me</button>
           <button class="tough-love-btn" @click="handleToughLove">Tough Love</button>
         </div>
+        <button class="settings-btn" @click="showSettings = true" aria-label="Open settings">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M8 10a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z" stroke="currentColor" stroke-width="1.5"/>
+            <path d="M13.3 9.6a1 1 0 0 0 .2 1.1l.04.04a1.2 1.2 0 0 1-1.7 1.7l-.04-.04a1 1 0 0 0-1.1-.2 1 1 0 0 0-.6.92v.12a1.2 1.2 0 0 1-2.4 0v-.06a1 1 0 0 0-.66-.92 1 1 0 0 0-1.1.2l-.04.04a1.2 1.2 0 0 1-1.7-1.7l.04-.04a1 1 0 0 0 .2-1.1 1 1 0 0 0-.92-.6H3.2a1.2 1.2 0 0 1 0-2.4h.06a1 1 0 0 0 .92-.66 1 1 0 0 0-.2-1.1l-.04-.04a1.2 1.2 0 0 1 1.7-1.7l.04.04a1 1 0 0 0 1.1.2h.05A1 1 0 0 0 7.4 3.2V3.1a1.2 1.2 0 0 1 2.4 0v.06a1 1 0 0 0 .6.92 1 1 0 0 0 1.1-.2l.04-.04a1.2 1.2 0 0 1 1.7 1.7l-.04.04a1 1 0 0 0-.2 1.1v.05a1 1 0 0 0 .92.6h.12a1.2 1.2 0 0 1 0 2.4h-.06a1 1 0 0 0-.92.6Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
       </div>
     </header>
 
@@ -236,11 +236,17 @@ function handleToughLove() { dismissEncouragement(); showToughLove() }
   }
 
   .app-controls {
-    flex-direction: column;
+    flex-wrap: wrap;
     gap: 6px;
   }
 
   .controls-meta {
+    flex: 1;
+    gap: 6px;
+  }
+
+  .controls-actions {
+    width: 100%;
     gap: 6px;
   }
 
@@ -258,10 +264,6 @@ function handleToughLove() { dismissEncouragement(); showToughLove() }
   .settings-btn {
     width: 36px;
     height: 36px;
-  }
-
-  .controls-actions {
-    gap: 6px;
   }
 
   .encourage-btn,

--- a/src/App.vue
+++ b/src/App.vue
@@ -243,11 +243,13 @@ function handleToughLove() { dismissEncouragement(); showToughLove() }
   .controls-meta {
     flex: 1;
     gap: 6px;
+    order: 1;
   }
 
   .controls-actions {
     width: 100%;
     gap: 6px;
+    order: 3;
   }
 
   .streak-display {
@@ -264,6 +266,7 @@ function handleToughLove() { dismissEncouragement(); showToughLove() }
   .settings-btn {
     width: 36px;
     height: 36px;
+    order: 2;
   }
 
   .encourage-btn,

--- a/tests/e2e/layout.spec.js
+++ b/tests/e2e/layout.spec.js
@@ -39,4 +39,15 @@ test.describe('layout', () => {
     await expect(page.locator('[data-column="next"] .add-task-btn')).toBeVisible()
     await expect(page.locator('[data-column="future"] .add-task-btn')).toBeVisible()
   })
+
+  test('settings cog is to the right of all other header buttons on desktop', async ({ page }) => {
+    const settingsBox = await page.getByRole('button', { name: /open settings/i }).boundingBox()
+    const encourageBox = await page.getByRole('button', { name: /encourage me/i }).boundingBox()
+    const toughLoveBox = await page.getByRole('button', { name: /tough love/i }).boundingBox()
+    const historyBox = await page.getByRole('button', { name: /history/i }).boundingBox()
+
+    expect(settingsBox.x).toBeGreaterThan(encourageBox.x)
+    expect(settingsBox.x).toBeGreaterThan(toughLoveBox.x)
+    expect(settingsBox.x).toBeGreaterThan(historyBox.x)
+  })
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { VitePWA } from 'vite-plugin-pwa'
+import { statSync } from 'fs'
+import { join } from 'path'
+
+// In a git worktree .git is a file, not a directory — default to 5174 to
+// avoid clashing with the main repo's dev server on 5173.
+const isWorktree = statSync(join(import.meta.dirname, '.git')).isFile()
+const defaultPort = isWorktree ? 5174 : 5173
 
 export default defineConfig({
   base: process.env.GITHUB_ACTIONS ? '/untangle/' : '/',
@@ -27,7 +34,7 @@ export default defineConfig({
   ],
   server: {
     host: '0.0.0.0',
-    port: parseInt(process.env.PORT) || 5173,
+    port: parseInt(process.env.PORT) || defaultPort,
   },
   test: {
     environment: 'jsdom',

--- a/vite.config.js
+++ b/vite.config.js
@@ -26,7 +26,8 @@ export default defineConfig({
     }),
   ],
   server: {
-    host: '0.0.0.0'
+    host: '0.0.0.0',
+    port: parseInt(process.env.PORT) || 5173,
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- Settings cog moved to the right of all other header buttons (streak, history, Encourage Me, Tough Love) on desktop
- Mobile layout unchanged — cog stays on the same row as streak and history
- Dev server auto-detects git worktrees and defaults to port 5174, avoiding conflicts with the main repo server on 5173
- Playwright now reuses an existing dev server when running locally (`reuseExistingServer: !process.env.CI`)

## Test plan
- [x] Unit tests updated and passing (247/247)
- [x] E2E tests updated and passing (132/132), including new assertion that cog x-position is right of all other header buttons
- [x] Build passes
- [x] Documentation updated (deploy-branch skill)
- [x] Manually verified desktop and mobile layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)