### PR TITLE
Fix coverage gate, add CI coverage job, test drag/drop and HistoryPanel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,40 @@ jobs:
         if: steps.e2e-tests.outcome == 'failure'
         run: exit 1
 
+  coverage:
+    name: Coverage gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run coverage
+        id: coverage
+        run: npm run test:coverage
+        continue-on-error: true
+
+      - name: Create issue for coverage failure
+        if: steps.coverage.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/bug-tracker.mjs create \
+            --title "Bug: Coverage gate failing on ${{ github.ref_name }}" \
+            --body "Coverage fell below threshold in CI run [#${{ github.run_number }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) on commit \`${{ github.sha }}\` (\`${{ github.ref_name }}\`)." \
+            --source "ci-unit-tests"
+
+      - name: Fail if coverage below threshold
+        if: steps.coverage.outcome == 'failure'
+        run: exit 1
+
   build:
     name: Build check
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ Full details on the workflow (skills, pipeline steps, and the test strategy that
 
 ---
 
+## What this repo demonstrates
+
+For anyone evaluating it as a portfolio project or engineering sample:
+
+- **AI-assisted SDLC governance** — every change goes through a structured pipeline (requirement capture → solution design → implementation → QA review → CI) enforced by git hooks and a custom workflow-state machine. Claude writes the code; the human author owns the architecture and signs off every change.
+- **Layered test strategy** — unit tests (Vitest) isolate composables and components; end-to-end tests (Playwright) cover full user journeys; a coverage gate (≥ 80% statements/lines/functions) is enforced both locally and in CI.
+- **CI/CD with GitHub Actions** — unit tests, E2E tests, coverage gate, and a production build check all run on every pull request. Failures automatically open GitHub issues with a link to the failing run.
+- **PWA delivery** — ships as an installable Progressive Web App (offline-capable, home-screen installable on iOS and Android) via Vite PWA plugin and a GitHub Pages deployment pipeline.
+- **Quality gates** — a `pre-push` hook blocks pushes without a QA approval marker; a `PreToolUse` hook blocks `gh pr create` without the same marker. Generated code that can't be read, reasoned about, and defended is treated as a liability.
+- **Accessibility-aware UX** — interactive elements carry ARIA roles and labels; keyboard navigation is preserved; dynamic content is announced to screen readers.
+
+---
+
 ## Wiki
 
 Full documentation lives in the [Untangle wiki](https://github.com/lauz9888/untangle/wiki):

--- a/src/composables/useTasks.js
+++ b/src/composables/useTasks.js
@@ -8,7 +8,11 @@ const STORAGE_KEY = 'untangle-tasks'
 const ENERGY_KEY = 'untangle-energy'
 
 function todayString() {
-  return new Date().toISOString().slice(0, 10)
+  const d = new Date()
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
 }
 const today = ref(todayString())
 setInterval(() => { today.value = todayString() }, 60_000)

--- a/tests/unit/drag-drop/composable.test.js
+++ b/tests/unit/drag-drop/composable.test.js
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { ref } from 'vue'
+
+const mockMoveTaskToColumn = vi.fn()
+
+vi.mock('../../../src/composables/useTasks.js', () => ({
+  useTasks: () => ({ moveTaskToColumn: mockMoveTaskToColumn }),
+}))
+
+// Imported after mock so the module picks up the stub above.
+import { useTaskDrag, activeTouchDragId } from '../../../src/composables/useDragDrop.js'
+
+function makeCardEl() {
+  const el = document.createElement('div')
+  el.getBoundingClientRect = () => ({ left: 10, top: 20, width: 200, height: 60 })
+  el.cloneNode = () => {
+    const clone = document.createElement('div')
+    clone.style = el.style
+    return clone
+  }
+  return ref(el)
+}
+
+function makeDragEvent(overrides = {}) {
+  return {
+    dataTransfer: { setData: vi.fn(), effectAllowed: null },
+    ...overrides,
+  }
+}
+
+function makeTouchEvent(x, y, type = 'touchstart') {
+  const touch = { clientX: x, clientY: y }
+  return Object.assign(new Event(type, { bubbles: true, cancelable: true }), {
+    touches: [touch],
+    changedTouches: [touch],
+    preventDefault: vi.fn(),
+  })
+}
+
+describe('useTaskDrag — HTML5 drag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    activeTouchDragId.value = null
+  })
+
+  it('sets isDragging and populates dataTransfer on dragstart', () => {
+    const cardEl = makeCardEl()
+    const editing = ref(false)
+    const { isDragging, onDragStart } = useTaskDrag('task-1', cardEl, editing)
+
+    const event = makeDragEvent()
+    onDragStart(event)
+
+    expect(isDragging.value).toBe(true)
+    expect(event.dataTransfer.setData).toHaveBeenCalledWith('text/plain', 'task-1')
+    expect(event.dataTransfer.effectAllowed).toBe('move')
+  })
+
+  it('clears isDragging on dragend', () => {
+    const cardEl = makeCardEl()
+    const editing = ref(false)
+    const { isDragging, onDragStart, onDragEnd } = useTaskDrag('task-1', cardEl, editing)
+
+    onDragStart(makeDragEvent())
+    expect(isDragging.value).toBe(true)
+    onDragEnd()
+    expect(isDragging.value).toBe(false)
+  })
+})
+
+describe('useTaskDrag — touch drag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    activeTouchDragId.value = null
+  })
+
+  afterEach(() => {
+    // Clean up any ghost elements left by the drag logic.
+    document.querySelectorAll('body > div').forEach(el => el.remove())
+  })
+
+  it('does not start drag when editing', () => {
+    const cardEl = makeCardEl()
+    const editing = ref(true)
+    const { isDragging, handleTouchStart } = useTaskDrag('task-2', cardEl, editing)
+
+    handleTouchStart(makeTouchEvent(50, 50))
+    // Move far enough to trigger a drag — if editing guard works, nothing happens.
+    const moveEvent = makeTouchEvent(100, 100, 'touchmove')
+    document.dispatchEvent(moveEvent)
+
+    expect(isDragging.value).toBe(false)
+  })
+
+  it('does not start drag when another touch drag is already active', () => {
+    activeTouchDragId.value = 'other-task'
+    const cardEl = makeCardEl()
+    const editing = ref(false)
+    const { isDragging, handleTouchStart } = useTaskDrag('task-3', cardEl, editing)
+
+    handleTouchStart(makeTouchEvent(50, 50))
+    expect(isDragging.value).toBe(false)
+  })
+
+  it('starts drag after moving past the 8px threshold', () => {
+    const cardEl = makeCardEl()
+    const editing = ref(false)
+    const { isDragging, handleTouchStart } = useTaskDrag('task-4', cardEl, editing)
+
+    handleTouchStart(makeTouchEvent(50, 50))
+
+    // Within threshold — no drag yet.
+    document.dispatchEvent(makeTouchEvent(54, 53, 'touchmove'))
+    expect(isDragging.value).toBe(false)
+
+    // Past threshold in X.
+    document.dispatchEvent(makeTouchEvent(60, 50, 'touchmove'))
+    expect(isDragging.value).toBe(true)
+    expect(activeTouchDragId.value).toBe('task-4')
+  })
+
+  it('appends a ghost element to the body during drag', () => {
+    const cardEl = makeCardEl()
+    document.body.appendChild(cardEl.value)
+    const editing = ref(false)
+    const { handleTouchStart } = useTaskDrag('task-5', cardEl, editing)
+
+    handleTouchStart(makeTouchEvent(50, 50))
+    document.dispatchEvent(makeTouchEvent(70, 50, 'touchmove'))
+
+    expect(document.body.querySelectorAll('div').length).toBeGreaterThan(0)
+    document.body.removeChild(cardEl.value)
+  })
+
+  it('calls moveTaskToColumn with the target column on touchend', () => {
+    const cardEl = makeCardEl()
+    const editing = ref(false)
+    const { handleTouchStart } = useTaskDrag('task-6', cardEl, editing)
+
+    // Create a column drop target.
+    const columnEl = document.createElement('div')
+    columnEl.dataset.column = 'next'
+    document.body.appendChild(columnEl)
+
+    // jsdom doesn't implement elementsFromPoint — define it so spyOn can stub it.
+    document.elementsFromPoint = () => []
+    vi.spyOn(document, 'elementsFromPoint').mockReturnValue([columnEl])
+
+    handleTouchStart(makeTouchEvent(50, 50))
+    document.dispatchEvent(makeTouchEvent(70, 50, 'touchmove'))
+    document.dispatchEvent(makeTouchEvent(70, 50, 'touchend'))
+
+    expect(mockMoveTaskToColumn).toHaveBeenCalledWith('task-6', 'next')
+    expect(activeTouchDragId.value).toBeNull()
+
+    document.body.removeChild(columnEl)
+    vi.restoreAllMocks()
+  })
+
+  it('cleans up state on touchcancel', () => {
+    const cardEl = makeCardEl()
+    const editing = ref(false)
+    const { isDragging, handleTouchStart } = useTaskDrag('task-7', cardEl, editing)
+
+    handleTouchStart(makeTouchEvent(50, 50))
+    document.dispatchEvent(makeTouchEvent(70, 50, 'touchmove'))
+    expect(isDragging.value).toBe(true)
+
+    document.dispatchEvent(new Event('touchcancel', { bubbles: true }))
+    expect(isDragging.value).toBe(false)
+    expect(activeTouchDragId.value).toBeNull()
+  })
+})

--- a/tests/unit/history/components.test.js
+++ b/tests/unit/history/components.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+
+// var is fully hoisted (initialised to undefined before module body runs).
+// The vi.mock factory runs after imports so ref() is available inside it.
+// eslint-disable-next-line no-var
+var mockTasks
+
+vi.mock('../../../src/composables/useTasks.js', () => {
+  mockTasks = ref([])
+  return { useTasks: () => ({ tasks: mockTasks }) }
+})
+
+import HistoryPanel from '../../../src/components/HistoryPanel.vue'
+
+function completedTask(daysAgo) {
+  const d = new Date()
+  d.setDate(d.getDate() - daysAgo)
+  return { id: String(Math.random()), completedAt: d.getTime() }
+}
+
+describe('HistoryPanel — components', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTasks.value = []
+  })
+
+  describe('empty state', () => {
+    it('shows empty message when no tasks have been completed', () => {
+      const wrapper = mount(HistoryPanel)
+      expect(wrapper.text()).toContain('No tasks completed yet.')
+    })
+
+    it('does not render the bar chart when there are no completed tasks', () => {
+      const wrapper = mount(HistoryPanel)
+      expect(wrapper.find('.bar-chart').exists()).toBe(false)
+    })
+
+    it('does not render the best-week section when there are no completed tasks', () => {
+      const wrapper = mount(HistoryPanel)
+      expect(wrapper.find('.best-week').exists()).toBe(false)
+    })
+  })
+
+  describe('with completed tasks', () => {
+    beforeEach(() => {
+      mockTasks.value = [
+        completedTask(0),
+        completedTask(1),
+        completedTask(8),
+      ]
+    })
+
+    it('renders the bar chart', () => {
+      const wrapper = mount(HistoryPanel)
+      expect(wrapper.find('.bar-chart').exists()).toBe(true)
+    })
+
+    it('renders four weekly columns', () => {
+      const wrapper = mount(HistoryPanel)
+      expect(wrapper.findAll('.bar-col').length).toBe(4)
+    })
+
+    it('renders the best-week section', () => {
+      const wrapper = mount(HistoryPanel)
+      expect(wrapper.find('.best-week').exists()).toBe(true)
+    })
+
+    it('bar-chart has a descriptive aria-label', () => {
+      const wrapper = mount(HistoryPanel)
+      const chart = wrapper.find('.bar-chart')
+      expect(chart.attributes('aria-label')).toContain('tasks completed')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has role=dialog on the panel', () => {
+      const wrapper = mount(HistoryPanel)
+      expect(wrapper.find('[role="dialog"]').exists()).toBe(true)
+    })
+
+    it('has aria-modal=true on the panel', () => {
+      const wrapper = mount(HistoryPanel)
+      expect(wrapper.find('[aria-modal="true"]').exists()).toBe(true)
+    })
+  })
+
+  describe('close interactions', () => {
+    it('emits close when the close button is clicked', async () => {
+      const wrapper = mount(HistoryPanel)
+      await wrapper.find('.panel-close').trigger('click')
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+
+    it('emits close when the overlay backdrop is clicked', async () => {
+      const wrapper = mount(HistoryPanel)
+      await wrapper.find('.history-overlay').trigger('click')
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+
+    it('does not emit close when the panel itself is clicked', async () => {
+      const wrapper = mount(HistoryPanel)
+      await wrapper.find('.history-panel').trigger('click')
+      // click.self on the overlay means clicking the inner panel should NOT close
+      expect(wrapper.emitted('close')).toBeFalsy()
+    })
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -44,6 +44,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/**'],
+      exclude: ['src/main.js'],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## Summary
- Fix `todayString()` in `useTasks.js` to use local date components — eliminates UTC midnight timezone bug
- Exclude `src/main.js` from coverage config; raise coverage to 90.8% statements / 92.2% lines (was ~69%/70%), clearing the 80% gate
- Add `coverage` job to CI so the gate is enforced on every PR
- Add 8 unit tests for `useTaskDrag` (HTML5 drag and full touch drag lifecycle)
- Add 11 unit tests for `HistoryPanel` (empty state, bar chart, best-week section, close interactions, accessibility attributes)
- Add "What this repo demonstrates" recruiter section to README

## Test plan
- [x] Unit tests updated and passing (271/271)
- [x] E2E tests passing (132/132)
- [x] Build passes
- [x] Coverage gate passes: 90.8% stmts / 88.3% branches / 87.9% fns / 92.2% lines
- [x] Documentation updated (README recruiter section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)