### PR TITLE
Lower bug-creation threshold across all workflow skills

### DIFF
--- a/.claude/skills/deploy-branch.md
+++ b/.claude/skills/deploy-branch.md
@@ -43,7 +43,7 @@ cd $project_root && npm test -- --run
 cd $project_root && npm run test:e2e
 ```
 
-For each test failure caused by a real source bug (not infrastructure), trigger `/report-bug` before fixing — use source `ci-unit-tests` for unit test failures or `ci-e2e-tests` for e2e failures. Provide the failure message and location. After the issue is created and the bug is fixed, re-run the failing suite to confirm it passes before continuing.
+For each test failure (excluding CI infrastructure issues such as network errors or missing environment dependencies), trigger `/report-bug` before fixing — use source `ci-unit-tests` for unit test failures or `ci-e2e-tests` for e2e failures. Provide the failure message and location. After the issue is created and the failure is resolved, re-run the failing suite to confirm it passes before continuing.
 
 ### 3. Stage and commit all changes
 

--- a/.claude/skills/deploy-main.md
+++ b/.claude/skills/deploy-main.md
@@ -43,7 +43,7 @@ cd $project_root && npm test -- --run
 cd $project_root && npm run test:e2e
 ```
 
-For each test failure caused by a real source bug, trigger `/report-bug` before fixing — use source `ci-unit-tests` for unit test failures or `ci-e2e-tests` for e2e failures. Provide the failure message and location. After the issue is created and the bug is fixed, re-run to confirm.
+For each test failure (excluding CI infrastructure issues such as network errors or missing environment dependencies), trigger `/report-bug` before fixing — use source `ci-unit-tests` for unit test failures or `ci-e2e-tests` for e2e failures. Provide the failure message and location. After the issue is created and the failure is resolved, re-run to confirm.
 
 ### 3. Stage and commit all changes (if not already committed)
 

--- a/.claude/skills/e2e-test-analysis.md
+++ b/.claude/skills/e2e-test-analysis.md
@@ -61,7 +61,7 @@ cd $project_root && npm run test:e2e -- <file1> <file2> ...
 
 Do not run the full suite at this step — the full suite runs in CI via `/deploy-branch` and `/deploy-main`.
 
-If a test fails because of a real bug in the source, trigger `/report-bug` with source `e2e-test` before fixing. Provide the test file, line, failure message, and what the test exercises. After the issue is created and the bug is fixed, re-run to confirm the tests pass.
+If any test fails, trigger `/report-bug` with source `e2e-test` before fixing. Provide the test file, line, failure message, and what the test exercises. After the issue is created and the failure is resolved, re-run to confirm the tests pass.
 
 ### 5. Advance to document analysis
 

--- a/.claude/skills/requirement-analysis.md
+++ b/.claude/skills/requirement-analysis.md
@@ -51,7 +51,7 @@ If the developer's initial message already answers most of these, confirm your u
 
 ### 3. Log a bug issue if the requirement is a bug fix
 
-If the requirement describes something currently broken — incorrect behaviour, a visual defect, a crash, or anything the user is reporting as wrong — create a GitHub issue before proceeding:
+If the requirement involves fixing something — incorrect behaviour, a visual defect, a crash, or anything the user is asking to be fixed or reporting as wrong — create a GitHub issue before proceeding:
 
 ```
 node scripts/bug-tracker.mjs create \

--- a/.claude/skills/unit-test-analysis.md
+++ b/.claude/skills/unit-test-analysis.md
@@ -54,7 +54,7 @@ Run only the test files that were changed or are directly related to the change:
 cd $project_root && npm test -- --run --reporter=verbose <test-file-pattern>
 ```
 
-If a test fails because of a real bug in the source (not a test setup issue), trigger `/report-bug` with source `unit-test` before fixing. Provide the test file, line, failure message, and what the test exercises. After the issue is created and the bug is fixed, re-run the tests to confirm they pass.
+If any test fails, trigger `/report-bug` with source `unit-test` before fixing. Provide the test file, line, failure message, and what the test exercises. After the issue is created and the failure is resolved, re-run the tests to confirm they pass.
 
 ### 5. Advance to e2e test analysis
 


### PR DESCRIPTION
## Summary
- Any test failure (unit, e2e, CI) now triggers `/report-bug` — removed the previous "real source bug only" qualifier
- `requirement-analysis` now logs a bug for any fix request, not just things explicitly described as broken
- CI skills (`deploy-branch`, `deploy-main`) still exclude pure infrastructure failures (network errors, missing env deps)

## Test plan
- [x] Unit tests passing (251/251)
- [x] E2E tests passing (132/132)
- [x] Build passes
- [x] No documentation changes needed (CLAUDE.md bug table already accurately describes the behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)