### PR TITLE
Fix vite crash in unzipped repos, Vue warning in drag-drop tests, and add workflow edit gate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/check-edit-gate.mjs"
+          }
+        ]
+      }
     ]
   }
 }

--- a/scripts/check-edit-gate.mjs
+++ b/scripts/check-edit-gate.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// PreToolUse hook: block Edit/Write on src/ files until the solution is approved.
+import { readFileSync, existsSync } from 'fs';
+import { execSync } from 'child_process';
+import { join, relative } from 'path';
+
+function getRepoRoot() {
+  return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+}
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', () => {
+  let toolInput;
+  try {
+    const data = JSON.parse(input);
+    toolInput = data.tool_input || {};
+  } catch {
+    process.exit(0);
+  }
+
+  const filePath = toolInput.file_path || '';
+  if (!filePath) process.exit(0);
+
+  const repoRoot = getRepoRoot();
+  const rel = relative(repoRoot, filePath).replace(/\\/g, '/');
+
+  // Only gate src/ edits — tests, scripts, config, docs are unrestricted.
+  if (!rel.startsWith('src/')) process.exit(0);
+
+  const statePath = join(repoRoot, '.claude', 'workflow', 'state.json');
+  if (!existsSync(statePath)) process.exit(0);
+
+  let state;
+  try {
+    state = JSON.parse(readFileSync(statePath, 'utf8'));
+  } catch {
+    process.exit(0);
+  }
+
+  if (!state?.active) process.exit(0);
+  if (state.solution_approved) process.exit(0);
+
+  process.stdout.write(
+    `[WORKFLOW GATE] Cannot edit src/ — workflow is at step "${state.current_step}" and the solution has not been approved yet.\n` +
+    `Complete /requirement-analysis then /solution-analysis first. Editing src/ is only permitted once the solution is approved.`
+  );
+  process.exit(2);
+});

--- a/scripts/workflow-state.mjs
+++ b/scripts/workflow-state.mjs
@@ -167,8 +167,12 @@ if (cmd === 'get') {
       if (state.loop_back_reason) lines.push(`Loop-back reason: ${state.loop_back_reason}`);
       if (state.awaiting_input && state.awaiting_input !== true) {
         lines.push(`Awaiting your answer to: ${state.awaiting_input}`);
+        lines.push(`ACTION REQUIRED: Answer the question above. Do not run any other workflow step or edit any files until you have responded to the awaiting question.`);
       } else if (state.awaiting_input) {
         lines.push(`Awaiting your answer to the last question asked.`);
+        lines.push(`ACTION REQUIRED: Answer the question above. Do not run any other workflow step or edit any files until you have responded to the awaiting question.`);
+      } else {
+        lines.push(`ACTION REQUIRED: You must immediately run /${state.current_step} to continue the workflow. Do not edit any source files and do not ask the user for permission first — just begin.`);
       }
       process.stdout.write(lines.join('\n'));
       process.exit(0);

--- a/src/composables/useDragDrop.js
+++ b/src/composables/useDragDrop.js
@@ -1,4 +1,4 @@
-import { ref, onBeforeUnmount } from 'vue'
+import { ref, onBeforeUnmount, getCurrentInstance } from 'vue'
 import { useTasks } from './useTasks.js'
 
 // Shared drag state so multiple components can coordinate touch drag.
@@ -116,10 +116,12 @@ export function useTaskDrag(taskId, cardEl, editing) {
     activeTouchDragId.value = null
   }
 
-  onBeforeUnmount(() => {
-    removeTouchListeners()
-    cleanupTouchDrag()
-  })
+  if (getCurrentInstance()) {
+    onBeforeUnmount(() => {
+      removeTouchListeners()
+      cleanupTouchDrag()
+    })
+  }
 
   return { isDragging, onDragStart, onDragEnd, handleTouchStart }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,14 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { VitePWA } from 'vite-plugin-pwa'
-import { statSync } from 'fs'
+import { existsSync, statSync } from 'fs'
 import { join } from 'path'
 
 // In a git worktree .git is a file, not a directory — default to 5174 to
 // avoid clashing with the main repo's dev server on 5173.
-const isWorktree = statSync(join(import.meta.dirname, '.git')).isFile()
+// Guard with existsSync so unzipped repos (no .git at all) don't throw.
+const gitPath = join(import.meta.dirname, '.git')
+const isWorktree = existsSync(gitPath) && statSync(gitPath).isFile()
 const defaultPort = isWorktree ? 5174 : 5173
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Guard `statSync('.git')` with `existsSync` in `vite.config.js` so the app starts correctly when downloaded as a zip (no `.git` folder) — fixes crash for recruiters/reviewers who don't clone
- Wrap `onBeforeUnmount` in a `getCurrentInstance()` check in `useDragDrop.js` so the lifecycle hook only registers inside component setup contexts, eliminating the Vue warning in unit tests
- Add `PreToolUse` hook (`scripts/check-edit-gate.mjs`) that blocks edits to `src/` files when the workflow solution hasn't been approved yet, enforcing that requirement-analysis and solution-analysis always run before code changes
- Strengthen `workflow-state.mjs` `check-prompt` to emit an `ACTION REQUIRED` directive when a workflow is active, not just a passive state dump

Closes #47, Closes #48

## Test plan
- [x] Unit tests: 271/271 passing, no Vue warnings in drag-drop suite
- [x] E2E tests: 132/132 passing
- [x] Build passes
- [x] Documentation: no changes needed (internal tooling only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)