### PR TITLE
Add overdue task alert icon with encouraging message

### DIFF
--- a/src/components/TaskCard.vue
+++ b/src/components/TaskCard.vue
@@ -5,6 +5,24 @@ import { useCelebration, STREAK_MILESTONES } from '../composables/useCelebration
 import { useTaskDrag } from '../composables/useDragDrop.js'
 import { ENERGY_LEVELS } from '../constants/energy.js'
 
+const OVERDUE_MESSAGES = [
+  "Every deadline is a chance to reset — what's a realistic date you can commit to today?",
+  "You've got this! Take a moment to choose a due date that actually works for you.",
+  "Progress, not perfection. Let's find a new timeline that sets you up to succeed.",
+  "Being honest with yourself about time is a superpower. Pick a date that feels achievable.",
+  "Plans change, and that's okay. What's a new due date you can genuinely commit to?",
+  "This task is still worth doing! When realistically could you get it done?",
+  "Rescheduling isn't failing — it's planning smarter. What date works better for you?",
+  "Future you will thank you for setting a realistic deadline. What date makes sense?",
+  "Take a breath — now, what's a due date you can actually meet?",
+  "Every great plan gets adjusted. What's your new target date for this one?",
+  "You're being thoughtful by reviewing this. What's a due date that respects your current capacity?",
+  "Timelines shift — what matters is keeping momentum. Set a new date and keep going!",
+  "Be kind to yourself. What's a due date that's both ambitious and realistic?",
+  "The best deadline is one you can actually meet. What date works for you now?",
+  "One small adjustment to the timeline could unlock a lot of momentum. What date feels right?",
+]
+
 const props = defineProps({
   task: { type: Object, required: true },
   isFirst: { type: Boolean, default: false },
@@ -52,6 +70,8 @@ const editEnergy = ref(null)
 const editDueDate = ref('')
 const editAvailableFrom = ref('')
 const newSubtaskTitle = ref('')
+const showOverdueMessage = ref(false)
+const overdueMessage = ref('')
 
 function startEdit() {
   editTitle.value = props.task.title
@@ -59,6 +79,12 @@ function startEdit() {
   editDueDate.value = props.task.dueDate ?? ''
   editAvailableFrom.value = props.task.availableFrom ?? ''
   newSubtaskTitle.value = ''
+  if (isOverdue.value) {
+    overdueMessage.value = OVERDUE_MESSAGES[Math.floor(Math.random() * OVERDUE_MESSAGES.length)]
+    showOverdueMessage.value = true
+  } else {
+    showOverdueMessage.value = false
+  }
   editing.value = true
 }
 
@@ -71,10 +97,12 @@ function saveEdit() {
     dueDate: editDueDate.value || null,
     availableFrom: editAvailableFrom.value || null,
   })
+  showOverdueMessage.value = false
   editing.value = false
 }
 
 function cancelEdit() {
+  showOverdueMessage.value = false
   editing.value = false
 }
 
@@ -100,7 +128,16 @@ function addSubtaskAction() {
 
     <!-- ── Display mode ── -->
     <template v-if="!editing">
-      <div class="task-main">
+      <button
+        v-if="isOverdue"
+        type="button"
+        class="overdue-alert-btn"
+        title="This task is overdue — click to review"
+        aria-label="Overdue task — click to update due date"
+        data-testid="overdue-alert-btn"
+        @click="startEdit"
+      >!</button>
+      <div class="task-main" :class="{ 'has-overdue-icon': isOverdue }">
         <p class="task-title" data-testid="task-title">{{ task.title }}</p>
         <div v-if="task.energy || task.dueDate || task.availableFrom" class="task-meta">
           <span v-if="task.energy" class="energy-badge" :class="`energy-${task.energy}`">{{ task.energy }}</span>
@@ -154,6 +191,8 @@ function addSubtaskAction() {
             >{{ level.label }}</button>
           </div>
         </fieldset>
+
+        <p v-if="showOverdueMessage" class="overdue-message" role="status">{{ overdueMessage }}</p>
 
         <div class="edit-dates">
           <div class="edit-date-field">
@@ -217,6 +256,54 @@ function addSubtaskAction() {
   transition: opacity 0.2s, box-shadow 0.15s;
   cursor: grab;
   user-select: none;
+  position: relative;
+}
+
+.overdue-alert-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: none;
+  background: var(--energy-large-bg);
+  color: var(--energy-large-active);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: background 0.12s, transform 0.1s;
+  z-index: 1;
+}
+
+.overdue-alert-btn:hover {
+  background: var(--energy-large-active);
+  color: #fff;
+  transform: scale(1.1);
+}
+
+.overdue-alert-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.task-main.has-overdue-icon {
+  padding-right: 26px;
+}
+
+.overdue-message {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 7px;
+  background: var(--energy-large-bg);
+  color: var(--energy-large-active);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .task-card:hover {

--- a/tests/e2e/task-editing.spec.js
+++ b/tests/e2e/task-editing.spec.js
@@ -1,6 +1,13 @@
 import { test, expect } from '@playwright/test'
 import { addTask, taskCard, openEdit } from './helpers.js'
 
+async function addTaskWithPastDueDate(page, column, title) {
+  await addTask(page, column, title)
+  const editCard = await openEdit(page, column, title)
+  await editCard.locator('[data-testid="due-date-input"]').fill('2020-01-01')
+  await editCard.locator('.btn-primary').click()
+}
+
 test.describe('task editing', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
@@ -67,5 +74,51 @@ test.describe('task editing', () => {
     await editCard.locator('.subtask-input').fill('New subtask')
     await editCard.locator('.btn-subtle').click()
     await expect(editCard.locator('.subtask-title')).toContainText('New subtask')
+  })
+
+  test.describe('overdue alert', () => {
+    test('shows the alert icon on a task with a past due date', async ({ page }) => {
+      await addTaskWithPastDueDate(page, 'now', 'Overdue task')
+      await expect(taskCard(page, 'now', 'Overdue task').locator('[data-testid="overdue-alert-btn"]')).toBeVisible()
+    })
+
+    test('does not show the alert icon on a task with no due date', async ({ page }) => {
+      await addTask(page, 'now', 'No due date task')
+      await expect(taskCard(page, 'now', 'No due date task').locator('[data-testid="overdue-alert-btn"]')).not.toBeVisible()
+    })
+
+    test('clicking the alert icon opens edit mode', async ({ page }) => {
+      await addTaskWithPastDueDate(page, 'now', 'Overdue task')
+      await taskCard(page, 'now', 'Overdue task').locator('[data-testid="overdue-alert-btn"]').click()
+      await expect(page.locator('.task-card.is-editing')).toBeVisible()
+    })
+
+    test('edit form shows the overdue message when opened via the alert icon', async ({ page }) => {
+      await addTaskWithPastDueDate(page, 'now', 'Overdue task')
+      await taskCard(page, 'now', 'Overdue task').locator('[data-testid="overdue-alert-btn"]').click()
+      await expect(page.locator('.task-card.is-editing .overdue-message')).toBeVisible()
+    })
+
+    test('overdue message is not shown when editing a task with no due date', async ({ page }) => {
+      await addTask(page, 'now', 'No due date task')
+      await openEdit(page, 'now', 'No due date task')
+      await expect(page.locator('.task-card.is-editing .overdue-message')).not.toBeVisible()
+    })
+
+    test('overdue message disappears after saving', async ({ page }) => {
+      await addTaskWithPastDueDate(page, 'now', 'Overdue task')
+      await taskCard(page, 'now', 'Overdue task').locator('[data-testid="overdue-alert-btn"]').click()
+      await expect(page.locator('.task-card.is-editing .overdue-message')).toBeVisible()
+      await page.locator('.task-card.is-editing .btn-primary').click()
+      await expect(page.locator('.overdue-message')).not.toBeVisible()
+    })
+
+    test('overdue message disappears after cancelling', async ({ page }) => {
+      await addTaskWithPastDueDate(page, 'now', 'Overdue task')
+      await taskCard(page, 'now', 'Overdue task').locator('[data-testid="overdue-alert-btn"]').click()
+      await expect(page.locator('.task-card.is-editing .overdue-message')).toBeVisible()
+      await page.locator('.task-card.is-editing .btn-secondary').click()
+      await expect(page.locator('.overdue-message')).not.toBeVisible()
+    })
   })
 })

--- a/tests/unit/task-editing/components.test.js
+++ b/tests/unit/task-editing/components.test.js
@@ -157,4 +157,77 @@ describe('task editing — components', () => {
       expect(wrapper.find('.edit-form').exists()).toBe(false)
     })
   })
+
+  describe('overdue alert icon', () => {
+    const overdueTask = makeTask({ dueDate: '2020-01-01' })
+    const futureTask = makeTask({ dueDate: '2099-12-31' })
+
+    it('shows the alert icon when the task due date is in the past', () => {
+      const wrapper = mount(TaskCard, { props: { task: overdueTask } })
+      expect(wrapper.find('[data-testid="overdue-alert-btn"]').exists()).toBe(true)
+    })
+
+    it('does not show the alert icon when the task has no due date', () => {
+      const wrapper = mount(TaskCard, { props: { task: baseTask } })
+      expect(wrapper.find('[data-testid="overdue-alert-btn"]').exists()).toBe(false)
+    })
+
+    it('does not show the alert icon when the due date is in the future', () => {
+      const wrapper = mount(TaskCard, { props: { task: futureTask } })
+      expect(wrapper.find('[data-testid="overdue-alert-btn"]').exists()).toBe(false)
+    })
+
+    it('clicking the alert icon opens edit mode', async () => {
+      const wrapper = mount(TaskCard, { props: { task: overdueTask } })
+      await wrapper.find('[data-testid="overdue-alert-btn"]').trigger('click')
+      expect(wrapper.find('.edit-form').exists()).toBe(true)
+    })
+  })
+
+  describe('overdue message in edit mode', () => {
+    const overdueTask = makeTask({ dueDate: '2020-01-01' })
+    const futureTask = makeTask({ dueDate: '2099-12-31' })
+
+    it('shows the overdue message when edit is opened on an overdue task via the alert icon', async () => {
+      const wrapper = mount(TaskCard, { props: { task: overdueTask } })
+      await wrapper.find('[data-testid="overdue-alert-btn"]').trigger('click')
+      const msg = wrapper.find('.overdue-message')
+      expect(msg.exists()).toBe(true)
+      expect(msg.text().length).toBeGreaterThan(0)
+    })
+
+    it('shows the overdue message when edit is opened on an overdue task via the edit button', async () => {
+      const wrapper = mount(TaskCard, { props: { task: overdueTask } })
+      await wrapper.find('.edit-btn').trigger('click')
+      expect(wrapper.find('.overdue-message').exists()).toBe(true)
+    })
+
+    it('does not show the overdue message when editing a task with no due date', async () => {
+      const wrapper = mount(TaskCard, { props: { task: baseTask } })
+      await wrapper.find('.edit-btn').trigger('click')
+      expect(wrapper.find('.overdue-message').exists()).toBe(false)
+    })
+
+    it('does not show the overdue message when editing a task with a future due date', async () => {
+      const wrapper = mount(TaskCard, { props: { task: futureTask } })
+      await wrapper.find('.edit-btn').trigger('click')
+      expect(wrapper.find('.overdue-message').exists()).toBe(false)
+    })
+
+    it('overdue message disappears after saving the edit', async () => {
+      const wrapper = mount(TaskCard, { props: { task: overdueTask } })
+      await wrapper.find('[data-testid="overdue-alert-btn"]').trigger('click')
+      expect(wrapper.find('.overdue-message').exists()).toBe(true)
+      await wrapper.find('.edit-form').trigger('submit')
+      expect(wrapper.find('.overdue-message').exists()).toBe(false)
+    })
+
+    it('overdue message disappears after cancelling the edit', async () => {
+      const wrapper = mount(TaskCard, { props: { task: overdueTask } })
+      await wrapper.find('[data-testid="overdue-alert-btn"]').trigger('click')
+      expect(wrapper.find('.overdue-message').exists()).toBe(true)
+      await wrapper.find('.btn-secondary').trigger('click')
+      expect(wrapper.find('.overdue-message').exists()).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Tasks with a past due date now show a persistent `!` alert icon in the top-right corner of the card
- Clicking the icon opens edit mode and displays a randomly chosen message from a list of 15 positive, encouraging prompts between the energy selector and date pickers
- The message prompts the user to commit to a new realistic due date; it clears on save or cancel
- Alert icon is always visible (not hover-only) as it serves as a notification; no change to existing overdue styling on the due date chip

## Test plan
- [x] Unit tests updated and passing (23 tests, 10 new)
- [x] E2E tests updated and passing (139 tests, 7 new)
- [x] Build passes
- [x] Manually tested on branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)