### PR TITLE
Add worktree and branch cleanup as final workflow step

### DIFF
--- a/.claude/skills/deploy-main.md
+++ b/.claude/skills/deploy-main.md
@@ -120,8 +120,28 @@ node scripts/workflow-state.mjs reset
 
 Tell the developer:
 - The PR number and that it has been merged to main
-- The source branch has been deleted
+- The source branch has been deleted from the remote
 - The report filename that was committed to `reports/`
-- The full workflow is complete
+- That the local worktree and branch are about to be removed
 
 If the wiki auto-update workflow is running, mention that it will update the GitHub wiki automatically.
+
+### 9. Clean up the local worktree and branch
+
+Capture the current worktree path and branch, then remove them. This is the last action in the session — the directory will be gone afterwards.
+
+```bash
+worktree_path=$(git rev-parse --show-toplevel)
+branch=$(git rev-parse --abbrev-ref HEAD)
+git_dir=$(git rev-parse --git-dir)
+
+if [ -f "${git_dir}/commondir" ]; then
+  common=$(cat "${git_dir}/commondir")
+  main_root=$(cd "${git_dir}/${common}/.." && pwd)
+  cd "$main_root"
+  git worktree remove "$worktree_path" --force
+  git branch -d "$branch" 2>/dev/null || git branch -D "$branch"
+fi
+```
+
+If not in a worktree (no `commondir` file), skip silently — there is nothing local to clean up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ When you send Claude a message asking for a code change, the workflow starts aut
 | 8a | `/deploy-branch` | Deploys to a branch for manual testing |
 | 8b | `/deploy-main` | Runs full CI and merges to main |
 | 9 | `/post-deploy-report` | Generates a change report (summary + bug analysis) and commits it to `reports/` |
+| 10 | (part of `/deploy-main`) | Deletes the source branch from the remote and removes the local git worktree |
 
 Each skill can also be run manually at any time by typing `/skill-name`.
 


### PR DESCRIPTION
## Summary
- Adds step 9 to `/deploy-main`: after reporting to the developer, detects if running in a git worktree and removes it along with the local branch ref
- Updates `CLAUDE.md` workflow table with a new step 10 entry describing the cleanup
- Remote branch deletion was already handled by `gh pr merge --delete-branch`; this adds the local side

## Test plan
- [x] Unit tests updated and passing (271/271 — no new tests needed, markdown-only change)
- [x] E2E tests updated and passing (132/132 — no new tests needed)
- [x] Build passes
- [x] Documentation updated (CLAUDE.md workflow table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)