### PR TITLE
Fix PWA validation: use vite preview instead of LHCI static server

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -16,10 +16,13 @@
 export default {
   ci: {
     collect: {
-      // The dist/ directory is built fresh in the pwa-validation job without
-      // GITHUB_ACTIONS=true so Vite uses base:'/' — assets load correctly when
-      // LHCI serves them from the local static server.
-      staticDistDir: './dist',
+      // Use `vite preview` rather than LHCI's built-in static server.
+      // The built-in server lacks SPA fallback and the correct MIME/cache
+      // headers that Vite sets, which causes NO_FCP in headless Chrome.
+      // `vite preview` serves the dist/ exactly as production would.
+      startServerCommand: 'npx vite preview --port 4173',
+      startServerReadyPattern: 'Local:',
+      url: ['http://localhost:4173/'],
       numberOfRuns: 1,
       settings: {
         // Required for headless Chrome on Linux CI runners.


### PR DESCRIPTION
## Summary

- Switches `.lighthouserc.js` from `staticDistDir` to `startServerCommand: 'npx vite preview --port 4173'`
- The LHCI built-in static server lacks SPA fallback routing and the correct MIME/cache headers that Vite sets, causing `NO_FCP` in headless Chrome on every run
- `vite preview` serves the `dist/` exactly as production would, resolving the blank-page / no-FCP failure

## Test plan

- [ ] Branch pipeline passes (build → unit → coverage → E2E → a11y → preview)
- [ ] After merge, main pipeline PWA validation job passes (no more NO_FCP)
- [ ] Lighthouse accessibility score ≥ 0.9 and best-practices score ≥ 0.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)