### PR TITLE
Require explicit bug-issue close step and cover fix-as-separate-PR case

### DIFF
--- a/.claude/skills/deploy-branch.md
+++ b/.claude/skills/deploy-branch.md
@@ -43,7 +43,7 @@ cd $project_root && npm test -- --run
 cd $project_root && npm run test:e2e
 ```
 
-For each test failure (excluding CI infrastructure issues such as network errors or missing environment dependencies), trigger `/report-bug` before fixing — use source `ci-unit-tests` for unit test failures or `ci-e2e-tests` for e2e failures. Provide the failure message and location. After the issue is created and the failure is resolved, re-run the failing suite to confirm it passes before continuing.
+For each test failure (excluding CI infrastructure issues such as network errors or missing environment dependencies), trigger `/report-bug` before fixing — use source `ci-unit-tests` for unit test failures or `ci-e2e-tests` for e2e failures. Provide the failure message and location. After the fix is confirmed passing, explicitly run the close step (`bug-tracker.mjs close`) before continuing — do not leave the issue open. If the fix cannot be made inline and requires its own PR, include `Closes #N` in that PR's commit message or body, then run `bug-tracker.mjs close` after the PR merges.
 
 ### 3. Stage and commit all changes
 

--- a/.claude/skills/deploy-main.md
+++ b/.claude/skills/deploy-main.md
@@ -43,7 +43,7 @@ cd $project_root && npm test -- --run
 cd $project_root && npm run test:e2e
 ```
 
-For each test failure (excluding CI infrastructure issues such as network errors or missing environment dependencies), trigger `/report-bug` before fixing — use source `ci-unit-tests` for unit test failures or `ci-e2e-tests` for e2e failures. Provide the failure message and location. After the issue is created and the failure is resolved, re-run to confirm.
+For each test failure (excluding CI infrastructure issues such as network errors or missing environment dependencies), trigger `/report-bug` before fixing — use source `ci-unit-tests` for unit test failures or `ci-e2e-tests` for e2e failures. Provide the failure message and location. After the fix is confirmed passing, explicitly run the close step (`bug-tracker.mjs close`) before continuing — do not leave the issue open. If the fix cannot be made inline and requires its own PR, include `Closes #N` in that PR's commit message or body, then run `bug-tracker.mjs close` after the PR merges.
 
 ### 3. Stage and commit all changes (if not already committed)
 

--- a/.claude/skills/report-bug.md
+++ b/.claude/skills/report-bug.md
@@ -50,6 +50,8 @@ If the output starts with `CREATED:N` — now tracked as issue #N. Note the numb
 
 Fix the underlying issue. Keep the fix minimal and targeted — do not refactor surrounding code.
 
+If the fix requires its own PR rather than an inline change, include `Closes #N` in that PR's commit message or body (where N is the issue number from step 2). After the PR merges, return here and complete step 4.
+
 ### 4. Close the issue
 
 ```


### PR DESCRIPTION
## Summary
- `deploy-branch.md` and `deploy-main.md`: explicit close step after CI failures — "re-run to confirm" wasn't enough, leaving issues open when sessions ended or fixes spanned separate PRs
- `report-bug.md`: step 3 now covers the fix-as-separate-PR case (include `Closes #N` in commit/PR, return to complete step 4 after merge)

## Why
Six CI-failure bug issues (#53–#56, #58, #60) were left open after their fixes landed because the instructions didn't say to run `bug-tracker.mjs close` explicitly, and there was no guidance for when the fix needed its own PR.

## Test plan
- [x] Unit tests passing (271/271)
- No code changes — skill instruction files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)