### PR TITLE
Fix PWA validation: rename .lighthouserc.js to .lighthouserc.cjs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -281,7 +281,7 @@ jobs:
 
       - name: Run Lighthouse CI (PWA + accessibility)
         id: lhci
-        run: npx @lhci/cli@0.14.x autorun --config=.lighthouserc.js
+        run: npx @lhci/cli@0.14.x autorun --config=.lighthouserc.cjs
         continue-on-error: true
 
       - name: Create issue for PWA / Lighthouse failure

--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -11,9 +11,15 @@
  *
  * Thresholds are intentionally pragmatic for an initial baseline:
  * raise them incrementally as the scores improve.
+ *
+ * NOTE: Must be .cjs (CommonJS) — LHCI uses require() to load config files,
+ * which fails for ES modules. Since this project has "type": "module" in
+ * package.json, a plain .js file would be treated as ESM and silently ignored,
+ * causing LHCI to fall back to auto-detection defaults (wrong static server,
+ * wrong URL, NO_FCP). The .cjs extension forces CommonJS regardless.
  */
 
-export default {
+module.exports = {
   ci: {
     collect: {
       // Use `vite preview` rather than LHCI's built-in static server.


### PR DESCRIPTION
## Root cause

The project has `"type": "module"` in `package.json`, which makes every `.js` file an ES module. LHCI 0.14.x uses `require()` internally to load config files — this **fails silently** for ES module files. LHCI then falls back to its auto-detection defaults:

- Starts its own built-in static server (port 38783, not 4173)
- Navigates to `/index.html` instead of `/`
- Ignores `startServerCommand`, `startServerReadyPattern`, `numberOfRuns`, `chromeFlags`
- Result: blank page → `NO_FCP` on every run

The `✅ Configuration file found` healthcheck only verifies the file *exists* — not that it was parsed successfully. This made the failure invisible.

## Fix

Rename `.lighthouserc.js` → `.lighthouserc.cjs`. The `.cjs` extension forces Node.js to treat the file as CommonJS regardless of `package.json` `"type"`, so `require()` succeeds and the full `collect` config is applied:

- `startServerCommand: 'npx vite preview --port 4173'` — proper SPA server
- `url: ['http://localhost:4173/']` — correct URL
- `numberOfRuns: 1` — one run, not three
- `chromeFlags: '--no-sandbox --disable-dev-shm-usage'` — required for headless CI

Update `main.yml` to reference `.lighthouserc.cjs`.

## Test plan

- [ ] Branch pipeline passes all checks
- [ ] After merge, main pipeline PWA validation job passes (LHCI picks up the config, uses vite preview, no NO_FCP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)