### PR TITLE
Clarify that branch deploy is only needed for manual testing

### DIFF
--- a/.claude/skills/deploy-main.md
+++ b/.claude/skills/deploy-main.md
@@ -1,6 +1,6 @@
 Run the full CI pipeline and deploy the change to main.
 
-This skill is part of the automated development workflow. It runs automatically when the developer chooses to skip branch testing, or is triggered manually with `/deploy-main` after branch testing.
+This skill is part of the automated development workflow. It is the default deployment path — triggered automatically when no manual browser testing is needed, or manually with `/deploy-main` after branch testing is complete.
 
 ## Steps
 

--- a/.claude/skills/document-analysis.md
+++ b/.claude/skills/document-analysis.md
@@ -46,14 +46,14 @@ Give the developer a concise summary of everything done in this workflow:
 Register the question so the workflow is blocked until the developer answers:
 
 ```
-node scripts/workflow-state.mjs await-input "Deploy to a branch for manual testing first, or directly to main?"
+node scripts/workflow-state.mjs await-input "Deploy directly to main, or deploy to a branch for manual testing first?"
 ```
 
 Then ask:
 
-> "Everything is complete. Would you like to:
-> - **Test manually first** — I'll deploy the changes to a branch so you can verify in a browser before merging
-> - **Deploy directly to main** — I'll run the full CI pipeline and merge straight to main"
+> "Everything is complete. How would you like to deploy?
+> - **Deploy directly to main** *(default)* — I'll run the full CI pipeline and merge straight to main. Choose this for logic, text, or config changes that don't need browser verification.
+> - **Test manually first** — I'll deploy to a branch so you can verify the change in a browser before merging. Choose this for UI or interaction changes where you want to see it working."
 
 End your turn. Do not continue until the developer responds.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,8 @@ When you send Claude a message asking for a code change, the workflow starts aut
 | 5 | `/unit-test-analysis` | Updates unit tests and runs affected tests |
 | 6 | `/e2e-test-analysis` | Updates e2e tests and runs affected tests |
 | 7 | `/document-analysis` | Updates docs, then asks about deployment path |
-| 8a | `/deploy-branch` | Deploys to a branch for manual testing |
-| 8b | `/deploy-main` | Runs full CI and merges to main |
+| 8a | `/deploy-branch` | Only when manual testing is needed — deploys to a branch so you can verify in a browser before merging |
+| 8b | `/deploy-main` | Default path — runs full CI and merges straight to main (use this unless you need browser verification) |
 | 9 | `/post-deploy-report` | Generates a change report (summary + bug analysis) and commits it to `reports/` |
 | 10 | (part of `/deploy-main`) | Deletes the source branch from the remote and removes the local git worktree |
 


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md workflow table to mark `/deploy-branch` as only needed when manual testing is required and `/deploy-main` as the default path
- Updated `document-analysis.md` to list deploy-main first with a *(default)* label and added guidance on when each path is appropriate
- Updated `deploy-main.md` opening description to reflect that it is the default deployment path, not a fallback when branch testing is skipped

## Test plan
- [x] Documentation-only change — no logic modified
- [x] Unit tests passing (271/271)
- [x] E2E tests passing (132/132)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)