### PR TITLE
Fix CI pipelines so every step runs on trigger

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -7,6 +7,8 @@ name: Branch pipeline
 on:
   pull_request:
     branches: [main]
+  push:
+    branches-ignore: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,6 +322,8 @@ jobs:
     name: Deploy production
     needs: docs-check
     runs-on: ubuntu-latest
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

- **branch.yml**: Restored the `push: branches-ignore: [main]` trigger so CI runs on every branch push, not just when a PR is opened or updated. The existing `if: github.event_name == 'pull_request'` guard on the `deploy-preview` job already correctly prevents the PR comment step from running on push events.
- **main.yml**: Added a job-level `outputs` block to the `deploy` job so `smoke-test` receives the actual deployed Pages URL via `needs.deploy.outputs.page_url`, instead of always silently falling back to the hardcoded URL.

## Test plan

- [ ] Verify branch pipeline runs on a push to a non-main branch (not just PR open/update)
- [ ] Verify `deploy-preview` comment still only posts on PR events
- [ ] Verify smoke-test in main pipeline uses the dynamic Pages URL from the deploy job

🤖 Generated with [Claude Code](https://claude.com/claude-code)