### PR TITLE
Add Untangle logo and tagline to the homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An energy-based task manager, built as a PWA.
 
+The homepage currently shows the Untangle logo and the tagline "Space to think"; the task manager itself is still being rebuilt.
+
 ## Getting started
 
 ```

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,27 +1,29 @@
 <script setup></script>
 
 <template>
-  <header class="brand">
-    <div class="logo">
-      <svg class="logo-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
-        <path
-          d="M4 16c0-2.5 2-4.5 4.5-4.5S13 13.5 13 16s-2 4.5-4.5 4.5S4 18.5 4 16z"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-        />
-        <path
-          d="M13 16h15"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-        />
-      </svg>
-      <h1>Untangle</h1>
-    </div>
-    <p class="tagline">Space to think</p>
-  </header>
+  <main>
+    <header class="brand">
+      <div class="logo">
+        <svg class="logo-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+          <path
+            d="M4 16c0-2.5 2-4.5 4.5-4.5S13 13.5 13 16s-2 4.5-4.5 4.5S4 18.5 4 16z"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          />
+          <path
+            d="M13 16h15"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+          />
+        </svg>
+        <h1>Untangle</h1>
+      </div>
+      <p class="tagline">Space to think</p>
+    </header>
+  </main>
 </template>
 
 <style scoped>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,21 +1,69 @@
 <script setup></script>
 
 <template>
-  <main>
-    <h1>Untangle</h1>
-    <p>Energy-based task manager — rebuild in progress.</p>
-  </main>
+  <header class="brand">
+    <div class="logo">
+      <svg
+        class="logo-icon"
+        viewBox="0 0 32 32"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          d="M4 16c0-2.5 2-4.5 4.5-4.5S13 13.5 13 16s-2 4.5-4.5 4.5S4 18.5 4 16z"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        />
+        <path
+          d="M13 16h15"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+        />
+      </svg>
+      <h1>Untangle</h1>
+    </div>
+    <p class="tagline">Space to think</p>
+  </header>
 </template>
 
 <style scoped>
-main {
-  max-width: 40rem;
-  margin: 4rem auto;
-  padding: 0 1.5rem;
+.brand {
+  position: absolute;
+  top: 1.5rem;
+  left: 1.5rem;
   font-family:
     system-ui,
     -apple-system,
     sans-serif;
-  text-align: center;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.logo-icon {
+  width: 1.75rem;
+  height: 1.75rem;
+  color: #1a1a1a;
+  flex-shrink: 0;
+}
+
+h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.tagline {
+  margin: 0.25rem 0 0 2.25rem;
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: #767676;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,12 +3,7 @@
 <template>
   <header class="brand">
     <div class="logo">
-      <svg
-        class="logo-icon"
-        viewBox="0 0 32 32"
-        aria-hidden="true"
-        focusable="false"
-      >
+      <svg class="logo-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
         <path
           d="M4 16c0-2.5 2-4.5 4.5-4.5S13 13.5 13 16s-2 4.5-4.5 4.5S4 18.5 4 16z"
           fill="none"

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,6 +1,14 @@
 import { test, expect } from '@playwright/test'
 
-test('loads the app shell', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
   await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+})
+
+test('shows the Untangle logo and tagline, with no other content', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Untangle' })).toBeVisible()
+  await expect(page.getByText('Space to think')).toBeVisible()
+  await expect(page.locator('nav')).toHaveCount(0)
+  await expect(page.locator('p')).toHaveCount(1)
 })

--- a/tests/unit/smoke.test.js
+++ b/tests/unit/smoke.test.js
@@ -3,8 +3,27 @@ import { mount } from '@vue/test-utils'
 import App from '../../src/App.vue'
 
 describe('App', () => {
-  it('renders the Untangle heading', () => {
+  it('renders the Untangle heading as the wordmark', () => {
     const wrapper = mount(App)
     expect(wrapper.find('h1').text()).toBe('Untangle')
+  })
+
+  it('renders the tagline beneath the logo', () => {
+    const wrapper = mount(App)
+    expect(wrapper.find('.tagline').text()).toBe('Space to think')
+  })
+
+  it('renders a decorative logo icon hidden from assistive tech', () => {
+    const wrapper = mount(App)
+    const icon = wrapper.find('svg')
+    expect(icon.exists()).toBe(true)
+    expect(icon.attributes('aria-hidden')).toBe('true')
+  })
+
+  it('renders no body content beyond the logo and tagline', () => {
+    const wrapper = mount(App)
+    expect(wrapper.findAll('p').length).toBe(1)
+    expect(wrapper.find('nav').exists()).toBe(false)
+    expect(wrapper.findAll('h1').length).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary
- Replaces the placeholder homepage with a blank landing page.
- Top-left corner shows the Untangle logo (a small abstract loop icon + the "Untangle" wordmark) with the tagline "Space to think" beneath it.
- No other content on the page (no nav, no body copy).

## Requirement
Replace the current placeholder homepage (App.vue) with a blank landing page. Top-left corner shows the Untangle logo: a small abstract icon (untangling line/knot motif) plus the 'Untangle' wordmark. The tagline 'Space to think' appears directly beneath the logo in smaller, lighter text. The rest of the page is fully blank -- no nav, no body copy, no other UI elements.

## Bugs found and resolved during the pipeline
- #77 (`e2e`): homepage was missing a `<main>` landmark, causing an axe-core accessibility violation. Fixed by wrapping the brand header in `<main>`.

## Test plan
- [x] Unit tests (`npx vitest run`) pass
- [x] Full e2e suite (`npm run test:e2e`, incl. accessibility) passes
- [x] Manual testing confirmed in browser