### PR TITLE
Add energy level selector with encouraging toast messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ npm run test:e2e        # end-to-end tests (Playwright, requires dev/build+previ
 
 All task state lives in `src/composables/useTasks.js` — a module-level singleton (Vue reactive refs outside the function). Every component that calls `useTasks()` shares the same state. Follow the same singleton pattern for any other cross-component state.
 
+`src/composables/useEnergyLevel.js` follows the same singleton pattern for the header's energy-level selector (`src/components/EnergySelector.vue`) and its toast notification (`src/components/ToastNotification.vue`): selecting a Low/Medium/High level picks a random encouraging message from a 20-message-per-level pool and shows it as a toast, which auto-dismisses after a few seconds or can be closed manually. Selection is in-memory only and always resets to "none" on reload.
+
 Components are thin: they call composable functions and render results. Business logic stays in composables.
 
 ## Test organisation
@@ -147,6 +149,7 @@ To trigger a wiki review outside the deploy workflow (e.g. after a direct wiki e
 | File                                 | Purpose                                                                            |
 | ------------------------------------ | ---------------------------------------------------------------------------------- |
 | `src/composables/useTasks.js`        | Task logic, energy filtering, localStorage persistence                             |
+| `src/composables/useEnergyLevel.js`  | Header energy-level selection state and toast message pools                        |
 | `scripts/workflow-state.mjs`         | 14-stage pipeline state machine (`start`/`get`/`set`/`approve`/`loopback`/`reset`) |
 | `scripts/bug-tracker.mjs`            | CLI for creating/closing GitHub bug issues, category list                          |
 | `scripts/check-docs.mjs`             | CI documentation-check job                                                         |

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,28 +1,35 @@
-<script setup></script>
+<script setup>
+import EnergySelector from './components/EnergySelector.vue'
+import ToastNotification from './components/ToastNotification.vue'
+</script>
 
 <template>
   <main>
     <header class="brand">
-      <div class="logo">
-        <svg class="logo-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
-          <path
-            d="M4 16c0-2.5 2-4.5 4.5-4.5S13 13.5 13 16s-2 4.5-4.5 4.5S4 18.5 4 16z"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          />
-          <path
-            d="M13 16h15"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-          />
-        </svg>
-        <h1>Untangle</h1>
+      <div class="brand-text">
+        <div class="logo">
+          <svg class="logo-icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+            <path
+              d="M4 16c0-2.5 2-4.5 4.5-4.5S13 13.5 13 16s-2 4.5-4.5 4.5S4 18.5 4 16z"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            />
+            <path
+              d="M13 16h15"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+            />
+          </svg>
+          <h1>Untangle</h1>
+        </div>
+        <p class="tagline">Space to think</p>
       </div>
-      <p class="tagline">Space to think</p>
+      <EnergySelector />
     </header>
+    <ToastNotification />
   </main>
 </template>
 
@@ -31,6 +38,11 @@
   position: absolute;
   top: 1.5rem;
   left: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
   font-family:
     system-ui,
     -apple-system,

--- a/src/components/EnergySelector.vue
+++ b/src/components/EnergySelector.vue
@@ -1,0 +1,59 @@
+<script setup>
+import { useEnergyLevel } from '../composables/useEnergyLevel.js'
+
+const LEVELS = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+]
+
+const { selectedLevel, selectLevel } = useEnergyLevel()
+</script>
+
+<template>
+  <div class="energy-selector" role="group" aria-label="Energy level">
+    <button
+      v-for="level in LEVELS"
+      :key="level.value"
+      type="button"
+      class="energy-option"
+      :class="{ selected: selectedLevel === level.value }"
+      :aria-pressed="selectedLevel === level.value"
+      @click="selectLevel(level.value)"
+    >
+      {{ level.label }}
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.energy-selector {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.energy-option {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid #d6d6d6;
+  background: #fff;
+  color: #1a1a1a;
+  cursor: pointer;
+}
+
+.energy-option:hover {
+  border-color: #a8a8a8;
+}
+
+.energy-option.selected {
+  background: #1a1a1a;
+  border-color: #1a1a1a;
+  color: #fff;
+}
+</style>

--- a/src/components/ToastNotification.vue
+++ b/src/components/ToastNotification.vue
@@ -1,0 +1,82 @@
+<script setup>
+import { watch, onUnmounted } from 'vue'
+import { useEnergyLevel } from '../composables/useEnergyLevel.js'
+
+const AUTO_DISMISS_MS = 4500
+
+const { toastMessage, toastId, dismissToast } = useEnergyLevel()
+
+let timeoutId = null
+
+function clearPendingDismiss() {
+  if (timeoutId !== null) {
+    clearTimeout(timeoutId)
+    timeoutId = null
+  }
+}
+
+watch(
+  toastId,
+  () => {
+    clearPendingDismiss()
+    if (toastMessage.value !== null) {
+      timeoutId = setTimeout(dismissToast, AUTO_DISMISS_MS)
+    }
+  },
+  { immediate: true }
+)
+
+onUnmounted(clearPendingDismiss)
+
+function handleClose() {
+  clearPendingDismiss()
+  dismissToast()
+}
+</script>
+
+<template>
+  <div v-if="toastMessage" class="toast" role="status" aria-live="polite">
+    <p class="toast-message">{{ toastMessage }}</p>
+    <button type="button" class="toast-close" aria-label="Dismiss" @click="handleClose">
+      &times;
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 2rem;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: 24rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: #1a1a1a;
+  color: #fff;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 0.9rem;
+  box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.2);
+}
+
+.toast-message {
+  margin: 0;
+}
+
+.toast-close {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+}
+</style>

--- a/src/composables/useEnergyLevel.js
+++ b/src/composables/useEnergyLevel.js
@@ -1,0 +1,110 @@
+import { ref } from 'vue'
+
+export const LOW_MESSAGES = [
+  "It's okay to take this slow today.",
+  'Small steps count just as much as big ones.',
+  'Rest is productive too.',
+  "You don't have to do it all right now.",
+  'One tiny task is plenty for today.',
+  'Being gentle with yourself is not a setback.',
+  'Low energy days deserve low-pressure plans.',
+  "You're allowed to just show up today.",
+  "Doing less today doesn't undo what you've built.",
+  "It's fine to pick just one thing and let the rest wait.",
+  "Taking care of yourself is today's priority.",
+  'A slow day is still a day moved forward.',
+  "You don't need to earn rest.",
+  'Whatever you manage today is enough.',
+  'Quiet days have their own kind of progress.',
+  "There's no rush — go at the pace that feels okay.",
+  'Showing up gently still counts as showing up.',
+  "It's alright to let today be simple.",
+  'You can pick this back up whenever you have more to give.',
+  "Softness today isn't a step backward.",
+]
+
+export const MEDIUM_MESSAGES = [
+  "You've got a good, steady amount to work with today.",
+  'This is a solid pace to get real things done.',
+  "You're right in the sweet spot for making progress.",
+  'Steady energy, steady progress.',
+  'This is plenty to tackle what is in front of you.',
+  'A balanced day is a good day to build momentum.',
+  'You can take on a few things without overdoing it.',
+  'This feels like a good day to make some headway.',
+  "Nice and steady — that's a great place to work from.",
+  'You have enough here to move things forward.',
+  'This is a comfortable pace for getting things done.',
+  'A middle-of-the-road day is still a productive one.',
+  "You're set up well to make solid progress today.",
+  'This is a good amount of energy to work with.',
+  'Consistent effort today will add up nicely.',
+  'You can pace yourself and still get plenty done.',
+  'This is a dependable kind of day.',
+  'Enough energy to make real progress, without overdoing it.',
+  'A grounded, steady day like this suits focused work.',
+  "You're well-positioned to make things happen today.",
+]
+
+export const HIGH_MESSAGES = [
+  "You're firing on all cylinders today!",
+  'Ride this momentum as far as it takes you!',
+  'This is your day to make big things happen!',
+  'Channel that energy into something great!',
+  "You've got the drive to tackle the big stuff today!",
+  "Let's turn this energy into real progress!",
+  'Today feels like a breakthrough kind of day!',
+  "Go get after it — you're ready!",
+  'This is the energy that gets big things done!',
+  'Make the most of this momentum!',
+  "You're unstoppable today!",
+  'Time to knock out everything on your list!',
+  'This is prime time to tackle your biggest goals!',
+  "Your energy is high — let's put it to great use!",
+  'Full speed ahead!',
+  'This is exactly the kind of day for bold moves!',
+  "You're ready to take on anything today!",
+  "Let's turn that spark into serious progress!",
+  "Today's got real momentum — use it well!",
+  "You're in a great place to push forward!",
+]
+
+const MESSAGE_POOLS = {
+  low: LOW_MESSAGES,
+  medium: MEDIUM_MESSAGES,
+  high: HIGH_MESSAGES,
+}
+
+const selectedLevel = ref(null)
+const toastMessage = ref(null)
+const toastId = ref(0)
+
+function randomMessage(level) {
+  const pool = MESSAGE_POOLS[level]
+  return pool[Math.floor(Math.random() * pool.length)]
+}
+
+function selectLevel(level) {
+  if (selectedLevel.value === level) {
+    selectedLevel.value = null
+    return
+  }
+
+  selectedLevel.value = level
+  toastMessage.value = randomMessage(level)
+  toastId.value += 1
+}
+
+function dismissToast() {
+  toastMessage.value = null
+}
+
+export function useEnergyLevel() {
+  return {
+    selectedLevel,
+    toastMessage,
+    toastId,
+    selectLevel,
+    dismissToast,
+  }
+}

--- a/tests/e2e/energy-selector.spec.js
+++ b/tests/e2e/energy-selector.spec.js
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test'
+import { energyButton, toast } from './helpers.js'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+})
+
+test('shows no energy level selected on first load', async ({ page }) => {
+  for (const label of ['Low', 'Medium', 'High']) {
+    await expect(energyButton(page, label)).toHaveAttribute('aria-pressed', 'false')
+  }
+  await expect(toast(page)).toHaveCount(0)
+})
+
+test('selecting a level highlights it and shows an encouraging toast', async ({ page }) => {
+  await energyButton(page, 'Low').click()
+
+  await expect(energyButton(page, 'Low')).toHaveAttribute('aria-pressed', 'true')
+  await expect(toast(page)).toBeVisible()
+  await expect(toast(page)).not.toBeEmpty()
+})
+
+test('clicking the selected level again deselects it and shows no new toast', async ({ page }) => {
+  await energyButton(page, 'Medium').click()
+  await expect(energyButton(page, 'Medium')).toHaveAttribute('aria-pressed', 'true')
+  const firstMessage = await toast(page).textContent()
+
+  await energyButton(page, 'Medium').click()
+
+  await expect(energyButton(page, 'Medium')).toHaveAttribute('aria-pressed', 'false')
+  const stillShowing = await toast(page).count()
+  if (stillShowing) {
+    await expect(toast(page)).toContainText(firstMessage)
+  }
+})
+
+test('switching directly to a different level replaces the toast', async ({ page }) => {
+  await energyButton(page, 'Low').click()
+  await expect(toast(page)).toBeVisible()
+
+  await energyButton(page, 'High').click()
+
+  await expect(energyButton(page, 'High')).toHaveAttribute('aria-pressed', 'true')
+  await expect(energyButton(page, 'Low')).toHaveAttribute('aria-pressed', 'false')
+  await expect(toast(page)).toBeVisible()
+})
+
+test('the toast can be dismissed manually', async ({ page }) => {
+  await energyButton(page, 'High').click()
+  await expect(toast(page)).toBeVisible()
+
+  await page.getByRole('button', { name: 'Dismiss' }).click()
+
+  await expect(toast(page)).toHaveCount(0)
+})
+
+test('the toast disappears on its own after a few seconds', async ({ page }) => {
+  await energyButton(page, 'Medium').click()
+  await expect(toast(page)).toBeVisible()
+
+  await expect(toast(page)).toHaveCount(0, { timeout: 8000 })
+})
+
+test('selection resets to none after a reload', async ({ page }) => {
+  await energyButton(page, 'High').click()
+  await expect(energyButton(page, 'High')).toHaveAttribute('aria-pressed', 'true')
+
+  await page.reload()
+
+  await expect(energyButton(page, 'High')).toHaveAttribute('aria-pressed', 'false')
+  await expect(toast(page)).toHaveCount(0)
+})

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -1,0 +1,7 @@
+export function energyButton(page, label) {
+  return page.getByRole('button', { name: label, exact: true })
+}
+
+export function toast(page) {
+  return page.getByRole('status')
+}

--- a/tests/unit/energy-level/components.test.js
+++ b/tests/unit/energy-level/components.test.js
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import EnergySelector from '../../../src/components/EnergySelector.vue'
+import ToastNotification from '../../../src/components/ToastNotification.vue'
+import App from '../../../src/App.vue'
+
+const state = {
+  selectedLevel: ref(null),
+  toastMessage: ref(null),
+  toastId: ref(0),
+  selectLevel: vi.fn(),
+  dismissToast: vi.fn(),
+}
+
+vi.mock('../../../src/composables/useEnergyLevel.js', () => ({
+  useEnergyLevel: () => state,
+}))
+
+let mountedWrappers = []
+
+function mountTracked(component) {
+  const wrapper = mount(component)
+  mountedWrappers.push(wrapper)
+  return wrapper
+}
+
+beforeEach(() => {
+  state.selectedLevel.value = null
+  state.toastMessage.value = null
+  state.toastId.value = 0
+  state.selectLevel.mockReset()
+  state.dismissToast.mockReset()
+})
+
+afterEach(() => {
+  mountedWrappers.forEach((wrapper) => wrapper.unmount())
+  mountedWrappers = []
+})
+
+describe('EnergySelector', () => {
+  it('renders Low, Medium and High options', () => {
+    const wrapper = mountTracked(EnergySelector)
+    const labels = wrapper.findAll('button').map((button) => button.text())
+    expect(labels).toEqual(['Low', 'Medium', 'High'])
+  })
+
+  it('calls selectLevel with the matching value when a button is clicked', async () => {
+    const wrapper = mountTracked(EnergySelector)
+    const buttons = wrapper.findAll('button')
+
+    await buttons[0].trigger('click')
+    expect(state.selectLevel).toHaveBeenCalledWith('low')
+
+    await buttons[1].trigger('click')
+    expect(state.selectLevel).toHaveBeenCalledWith('medium')
+
+    await buttons[2].trigger('click')
+    expect(state.selectLevel).toHaveBeenCalledWith('high')
+  })
+
+  it('marks the currently selected level as pressed and leaves the others unpressed', () => {
+    state.selectedLevel.value = 'medium'
+    const wrapper = mountTracked(EnergySelector)
+    const buttons = wrapper.findAll('button')
+
+    expect(buttons[0].attributes('aria-pressed')).toBe('false')
+    expect(buttons[1].attributes('aria-pressed')).toBe('true')
+    expect(buttons[2].attributes('aria-pressed')).toBe('false')
+  })
+
+  it('leaves every option unpressed when no level is selected', () => {
+    const wrapper = mountTracked(EnergySelector)
+    wrapper.findAll('button').forEach((button) => {
+      expect(button.attributes('aria-pressed')).toBe('false')
+    })
+  })
+})
+
+describe('ToastNotification', () => {
+  it('renders nothing when there is no toast message', () => {
+    const wrapper = mountTracked(ToastNotification)
+    expect(wrapper.find('[role="status"]').exists()).toBe(false)
+  })
+
+  it('renders the toast message with a polite live region when one is set', () => {
+    state.toastMessage.value = "You're doing just fine at this pace."
+    const wrapper = mountTracked(ToastNotification)
+
+    const toast = wrapper.find('[role="status"]')
+    expect(toast.exists()).toBe(true)
+    expect(toast.attributes('aria-live')).toBe('polite')
+    expect(toast.text()).toContain("You're doing just fine at this pace.")
+  })
+
+  it('calls dismissToast when the close button is clicked', async () => {
+    state.toastMessage.value = 'Small steps still count.'
+    const wrapper = mountTracked(ToastNotification)
+
+    await wrapper.find('button').trigger('click')
+
+    expect(state.dismissToast).toHaveBeenCalled()
+  })
+
+  describe('auto-dismiss timer', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('automatically dismisses the toast a few seconds after it appears', () => {
+      state.toastMessage.value = 'You are doing great.'
+      state.toastId.value = 1
+      mountTracked(ToastNotification)
+
+      expect(state.dismissToast).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(10000)
+
+      expect(state.dismissToast).toHaveBeenCalled()
+    })
+
+    it('restarts the auto-dismiss countdown when a new toast replaces the current one', async () => {
+      state.toastMessage.value = 'First message.'
+      state.toastId.value = 1
+      const wrapper = mountTracked(ToastNotification)
+
+      vi.advanceTimersByTime(3000)
+      expect(state.dismissToast).not.toHaveBeenCalled()
+
+      state.toastMessage.value = 'Second message.'
+      state.toastId.value = 2
+      await wrapper.vm.$nextTick()
+
+      vi.advanceTimersByTime(2000)
+      expect(state.dismissToast).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(10000)
+      expect(state.dismissToast).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not fire a stray auto-dismiss after the toast has already been closed manually', async () => {
+      state.toastMessage.value = 'Closed early.'
+      state.toastId.value = 1
+      const wrapper = mountTracked(ToastNotification)
+
+      await wrapper.find('button').trigger('click')
+      expect(state.dismissToast).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(10000)
+      expect(state.dismissToast).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('App', () => {
+  it('renders the energy selector and toast notification alongside the logo and tagline', () => {
+    const wrapper = mountTracked(App)
+
+    expect(wrapper.findComponent(EnergySelector).exists()).toBe(true)
+    expect(wrapper.findComponent(ToastNotification).exists()).toBe(true)
+    expect(wrapper.find('h1').text()).toBe('Untangle')
+    expect(wrapper.find('.tagline').text()).toBe('Space to think')
+  })
+})

--- a/tests/unit/energy-level/composable.test.js
+++ b/tests/unit/energy-level/composable.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const modulePath = '../../../src/composables/useEnergyLevel.js'
+
+async function load() {
+  const mod = await import(modulePath)
+  return mod.useEnergyLevel()
+}
+
+describe('useEnergyLevel', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('has no energy level selected by default', async () => {
+    const { selectedLevel } = await load()
+    expect(selectedLevel.value).toBe(null)
+  })
+
+  it('has no toast message by default', async () => {
+    const { toastMessage } = await load()
+    expect(toastMessage.value).toBe(null)
+  })
+
+  it.each(['low', 'medium', 'high'])(
+    'exposes exactly 20 unique messages for the %s level',
+    async (level) => {
+      const mod = await import(modulePath)
+      const pool = mod[`${level.toUpperCase()}_MESSAGES`]
+      expect(pool).toHaveLength(20)
+      expect(new Set(pool).size).toBe(20)
+      pool.forEach((message) => {
+        expect(typeof message).toBe('string')
+        expect(message.length).toBeGreaterThan(0)
+      })
+    }
+  )
+
+  it.each(['low', 'medium', 'high'])(
+    'selecting %s sets it as the selected level',
+    async (level) => {
+      const { selectedLevel, selectLevel } = await load()
+      selectLevel(level)
+      expect(selectedLevel.value).toBe(level)
+    }
+  )
+
+  it.each(['low', 'medium', 'high'])(
+    "selecting %s shows a toast message drawn from that level's pool",
+    async (level) => {
+      const mod = await import(modulePath)
+      const pool = mod[`${level.toUpperCase()}_MESSAGES`]
+      const { toastMessage, selectLevel } = mod.useEnergyLevel()
+      selectLevel(level)
+      expect(pool).toContain(toastMessage.value)
+    }
+  )
+
+  it('selects a message at random rather than always showing the same one', async () => {
+    const { toastMessage, selectLevel } = await load()
+    const seen = new Set()
+    for (let i = 0; i < 40; i++) {
+      selectLevel('high')
+      seen.add(toastMessage.value)
+      selectLevel('medium')
+    }
+    expect(seen.size).toBeGreaterThan(1)
+  })
+
+  it('clicking the currently selected level deselects it', async () => {
+    const { selectedLevel, selectLevel } = await load()
+    selectLevel('medium')
+    selectLevel('medium')
+    expect(selectedLevel.value).toBe(null)
+  })
+
+  it('clicking the currently selected level does not change or clear the toast message', async () => {
+    const { toastMessage, toastId, selectLevel } = await load()
+    selectLevel('medium')
+    const messageAfterSelect = toastMessage.value
+    const idAfterSelect = toastId.value
+
+    selectLevel('medium')
+
+    expect(toastMessage.value).toBe(messageAfterSelect)
+    expect(toastId.value).toBe(idAfterSelect)
+  })
+
+  it('switching directly from one level to another updates the selection and fires a new toast', async () => {
+    const { selectedLevel, toastId, selectLevel } = await load()
+    selectLevel('low')
+    const firstToastId = toastId.value
+
+    selectLevel('high')
+
+    expect(selectedLevel.value).toBe('high')
+    expect(toastId.value).toBeGreaterThan(firstToastId)
+  })
+
+  it('dismissToast clears the current toast message', async () => {
+    const { toastMessage, selectLevel, dismissToast } = await load()
+    selectLevel('low')
+    expect(toastMessage.value).not.toBe(null)
+
+    dismissToast()
+
+    expect(toastMessage.value).toBe(null)
+  })
+
+  it('shares state across every call as a singleton', async () => {
+    const mod = await import(modulePath)
+    const first = mod.useEnergyLevel()
+    const second = mod.useEnergyLevel()
+
+    first.selectLevel('high')
+
+    expect(second.selectedLevel.value).toBe('high')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a Low/Medium/High energy-selection panel to the header, to the right of the logo/tagline
- Selecting a level shows a toast with one message chosen at random from a pool of 20 encouraging/reassuring messages, tuned in tone to that level (gentle for Low, balanced for Medium, energizing for High)
- Re-clicking the currently selected level deselects it with no new toast; switching directly to a different level replaces the toast
- Toast auto-dismisses after a few seconds and has a manual close button
- No level is selected by default, and selection never persists across reloads

## Test plan
- [x] `npm test -- run` — 32 unit tests passing (composable + component coverage, including auto-dismiss timer behavior)
- [x] `npm run test:e2e` — 9 e2e tests passing (7 new energy-selector specs + 2 pre-existing smoke/a11y specs, no regressions)
- [x] Manual testing confirmed by user in the local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)