### PR TITLE
Deploy main to GitHub Pages on merge

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,42 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+        env:
+          GITHUB_PAGES: true
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,10 @@ The documentation-check job is a nudge, not a wiki editor — it can't run Claud
 
 Any job failing blocks the merge and is logged as the matching `ci-*` bug (see the table above), closed once the job passes.
 
+## Deployment
+
+Merges to `main` are built and published to GitHub Pages by `.github/workflows/deploy-pages.yml`, live at [lauz9888.github.io/untangle](https://lauz9888.github.io/untangle/). The build sets `GITHUB_PAGES=true` so `vite.config.js` serves assets under the `/untangle/` base path a GitHub Pages project site needs (local dev/build/preview are unaffected — they default to `/`). This is a separate workflow from `ci.yml`; it doesn't gate PRs, it only runs after a merge lands on `main`.
+
 ## Wiki updates
 
 The [GitHub wiki](https://github.com/lauz9888/untangle/wiki) is updated as part of `/deploy-main`. It's a separate git repository (`untangle.wiki.git`) with no branch protection, pushed to directly.
@@ -157,4 +161,5 @@ To trigger a wiki review outside the deploy workflow (e.g. after a direct wiki e
 | `scripts/post-commit-close-bugs.mjs` | `post-commit` git hook logic (auto-closes bugs via commit trailers)                |
 | `.claude/skills/`                    | The 14 pipeline skills plus `report-bug` and `wiki-update`                         |
 | `.github/workflows/ci.yml`           | The 9-job CI pipeline                                                              |
+| `.github/workflows/deploy-pages.yml` | Builds and publishes `main` to GitHub Pages after merge                            |
 | `reports/`                           | Post-deploy change reports, one markdown file per merged change                    |

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import vue from '@vitejs/plugin-vue'
 import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
+  base: process.env.GITHUB_PAGES ? '/untangle/' : '/',
   plugins: [
     vue(),
     VitePWA({


### PR DESCRIPTION
## Summary
- CI (`ci.yml`) only builds and tests on PRs — nothing actually publishes `dist/` anywhere, so GitHub Pages (already enabled in repo settings, pointing at `lauz9888.github.io/untangle`) was still serving a stale build from before the repo was reset and rebuilt through the new pipeline
- Adds `.github/workflows/deploy-pages.yml`: builds and publishes to Pages via `actions/upload-pages-artifact` + `actions/deploy-pages` after every merge to `main` (doesn't gate PRs, runs independently of `ci.yml`)
- `vite.config.js` now sets `base: '/untangle/'` only when `GITHUB_PAGES=true` (set by the new workflow), since a GitHub Pages project site is served under a subpath — local dev/build/preview and the existing CI build are unaffected (verified both builds locally: asset paths default to `/` normally, and correctly prefix `/untangle/` under `GITHUB_PAGES=true`)
- `CLAUDE.md` updated with a new Deployment section and key-files entry

## Test plan
- [x] `npm run build` (no env var) — asset paths remain `/...` as before
- [x] `GITHUB_PAGES=true npm run build` — asset paths and PWA manifest `start_url`/`scope` correctly become `/untangle/...`
- [x] `npm test -- run` — 32 unit tests passing, unaffected
- [x] `npm run test:e2e` — 9 e2e tests passing, unaffected
- [ ] After merge: confirm the `Deploy Pages` workflow runs and `lauz9888.github.io/untangle` actually updates to the current app

🤖 Generated with [Claude Code](https://claude.com/claude-code)