### PR TITLE
Fix E2E tests CI job to run the full suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium
-      - run: npx playwright test tests/e2e/smoke.spec.js
+      - run: npx playwright test tests/e2e
 
   a11y:
     name: Accessibility tests


### PR DESCRIPTION
## Summary
- The "E2E tests" CI job hardcoded `npx playwright test tests/e2e/smoke.spec.js` — every other spec (including the recently-added `energy-selector.spec.js`) never actually ran in CI; it just happened to pass locally, and the green checkmark on past PRs gave false confidence
- Changes the job to `npx playwright test tests/e2e`, so any spec added under `tests/e2e/` is picked up automatically going forward instead of silently skipped
- `tests/e2e/a11y.spec.js` now runs in both this job and the dedicated "Accessibility tests" job — small, cheap overlap (~1s) traded for not needing a Playwright project-matrix just to dedupe one fast test

## Test plan
- [x] `npx playwright test tests/e2e` locally — all 9 specs run and pass (previously only `smoke.spec.js`'s 1 test would have run under the old command)
- [x] `npm test -- run` — 32 unit tests unaffected
- [x] This PR's own CI run exercises the new command for real, since GitHub Actions uses the workflow file from the PR branch for `pull_request` triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)