### PR TITLE
Add Encourage me button

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ npm run test:e2e        # end-to-end tests (Playwright, requires dev/build+previ
 
 All task state lives in `src/composables/useTasks.js` — a module-level singleton (Vue reactive refs outside the function). Every component that calls `useTasks()` shares the same state. Follow the same singleton pattern for any other cross-component state.
 
-`src/composables/useEnergyLevel.js` follows the same singleton pattern for the header's energy-level selector (`src/components/EnergySelector.vue`) and its toast notification (`src/components/ToastNotification.vue`): selecting a Low/Medium/High level picks a random encouraging message from a 20-message-per-level pool and shows it as a toast, which auto-dismisses after a few seconds or can be closed manually. Selection is in-memory only and always resets to "none" on reload.
+`src/composables/useEnergyLevel.js` follows the same singleton pattern for the header's energy-level selector (`src/components/EnergySelector.vue`, grouped in its own labeled panel), the standalone "Encourage me" button (`src/components/EncourageButton.vue`), and their shared toast notification (`src/components/ToastNotification.vue`): selecting a Low/Medium/High level picks a random encouraging message from a 20-message-per-level pool, and the "Encourage me" button picks one from a separate 50-message general pool, either way showing it as a toast that auto-dismisses after a few seconds or can be closed manually. Selection is in-memory only and always resets to "none" on reload.
 
 Components are thin: they call composable functions and render results. Business logic stays in composables.
 
@@ -153,7 +153,7 @@ To trigger a wiki review outside the deploy workflow (e.g. after a direct wiki e
 | File                                 | Purpose                                                                            |
 | ------------------------------------ | ---------------------------------------------------------------------------------- |
 | `src/composables/useTasks.js`        | Task logic, energy filtering, localStorage persistence                             |
-| `src/composables/useEnergyLevel.js`  | Header energy-level selection state and toast message pools                        |
+| `src/composables/useEnergyLevel.js`  | Header energy-level selection state, "Encourage me" toast, and message pools       |
 | `scripts/workflow-state.mjs`         | 14-stage pipeline state machine (`start`/`get`/`set`/`approve`/`loopback`/`reset`) |
 | `scripts/bug-tracker.mjs`            | CLI for creating/closing GitHub bug issues, category list                          |
 | `scripts/check-docs.mjs`             | CI documentation-check job                                                         |

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <script setup>
 import EnergySelector from './components/EnergySelector.vue'
+import EncourageButton from './components/EncourageButton.vue'
 import ToastNotification from './components/ToastNotification.vue'
 </script>
 
@@ -27,7 +28,10 @@ import ToastNotification from './components/ToastNotification.vue'
         </div>
         <p class="tagline">Space to think</p>
       </div>
-      <EnergySelector />
+      <div class="header-actions">
+        <EnergySelector />
+        <EncourageButton />
+      </div>
     </header>
     <ToastNotification />
   </main>
@@ -74,5 +78,11 @@ h1 {
   font-size: 0.85rem;
   font-weight: 400;
   color: #767676;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 </style>

--- a/src/components/EncourageButton.vue
+++ b/src/components/EncourageButton.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { useEnergyLevel } from '../composables/useEnergyLevel.js'
+
+const { encourageMe } = useEnergyLevel()
+</script>
+
+<template>
+  <button type="button" class="encourage-button" @click="encourageMe">Encourage me</button>
+</template>
+
+<style scoped>
+.encourage-button {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid #d6d6d6;
+  background: #fff;
+  color: #1a1a1a;
+  cursor: pointer;
+}
+
+.encourage-button:hover {
+  border-color: #a8a8a8;
+}
+</style>

--- a/src/components/EnergySelector.vue
+++ b/src/components/EnergySelector.vue
@@ -11,22 +11,47 @@ const { selectedLevel, selectLevel } = useEnergyLevel()
 </script>
 
 <template>
-  <div class="energy-selector" role="group" aria-label="Energy level">
-    <button
-      v-for="level in LEVELS"
-      :key="level.value"
-      type="button"
-      class="energy-option"
-      :class="{ selected: selectedLevel === level.value }"
-      :aria-pressed="selectedLevel === level.value"
-      @click="selectLevel(level.value)"
-    >
-      {{ level.label }}
-    </button>
+  <div class="energy-panel">
+    <span id="energy-panel-label" class="energy-panel-label">Energy level</span>
+    <div class="energy-selector" role="group" aria-labelledby="energy-panel-label">
+      <button
+        v-for="level in LEVELS"
+        :key="level.value"
+        type="button"
+        class="energy-option"
+        :class="{ selected: selectedLevel === level.value }"
+        :aria-pressed="selectedLevel === level.value"
+        @click="selectLevel(level.value)"
+      >
+        {{ level.label }}
+      </button>
+    </div>
   </div>
 </template>
 
 <style scoped>
+.energy-panel {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: #f0f0f0;
+  border: 1px solid #e2e2e2;
+}
+
+.energy-panel-label {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: #595959;
+}
+
 .energy-selector {
   display: flex;
   gap: 0.5rem;

--- a/src/composables/useEnergyLevel.js
+++ b/src/composables/useEnergyLevel.js
@@ -69,6 +69,59 @@ export const HIGH_MESSAGES = [
   "You're in a great place to push forward!",
 ]
 
+export const ENCOURAGEMENT_MESSAGES = [
+  'Every bit of progress counts.',
+  "You're doing better than you think.",
+  'One task at a time is still moving forward.',
+  "It's okay to go at your own pace.",
+  'You showed up today, and that matters.',
+  'Small wins add up to big change.',
+  "You've got this.",
+  'Progress, not perfection.',
+  'Be proud of how far you have come.',
+  "You're allowed to take this one step at a time.",
+  'Whatever you get done today is enough.',
+  "Keep going — you're closer than you think.",
+  'Trust the process, one step at a time.',
+  'Your effort today matters, even the quiet parts.',
+  "You're capable of more than you realize.",
+  'Take a breath — you are handling this well.',
+  "There's no wrong way to make progress.",
+  'You are exactly where you need to be right now.',
+  'Give yourself credit for showing up.',
+  'Momentum builds from small steps.',
+  'You are allowed to be a work in progress.',
+  "Today's effort is tomorrow's progress.",
+  'Believe in the process you are building.',
+  "You're doing just fine.",
+  'One task down is still a win.',
+  "It's okay if today looks different than planned.",
+  'You bring more to this than you know.',
+  'Keep chipping away — it adds up.',
+  'You are not behind, you are on your own path.',
+  "Celebrate the small stuff — it's not small.",
+  'This moment of effort counts.',
+  "You're building something, even on quiet days.",
+  'Your best today is good enough.',
+  'Steady effort beats perfect effort.',
+  "You've handled hard days before, and you can handle this one.",
+  'Every step forward is still forward.',
+  'You are doing the work, and that is enough.',
+  "Give yourself the same kindness you'd give a friend.",
+  'This is a good moment to keep going.',
+  "You're allowed to feel good about small progress.",
+  'Trust yourself — you know more than you think.',
+  'You are not alone in finding this hard sometimes.',
+  'Keep your pace — it is the right one for you.',
+  "You're making it happen, one piece at a time.",
+  'This effort is not wasted, even if it feels slow.',
+  'You are worth the same patience you give others.',
+  "Today counts, even if it's a small day.",
+  'You are further along than you were yesterday.',
+  'Nice work getting this far.',
+  "You've got what it takes to keep moving.",
+]
+
 const MESSAGE_POOLS = {
   low: LOW_MESSAGES,
   medium: MEDIUM_MESSAGES,
@@ -79,8 +132,7 @@ const selectedLevel = ref(null)
 const toastMessage = ref(null)
 const toastId = ref(0)
 
-function randomMessage(level) {
-  const pool = MESSAGE_POOLS[level]
+function randomFrom(pool) {
   return pool[Math.floor(Math.random() * pool.length)]
 }
 
@@ -91,7 +143,12 @@ function selectLevel(level) {
   }
 
   selectedLevel.value = level
-  toastMessage.value = randomMessage(level)
+  toastMessage.value = randomFrom(MESSAGE_POOLS[level])
+  toastId.value += 1
+}
+
+function encourageMe() {
+  toastMessage.value = randomFrom(ENCOURAGEMENT_MESSAGES)
   toastId.value += 1
 }
 
@@ -105,6 +162,7 @@ export function useEnergyLevel() {
     toastMessage,
     toastId,
     selectLevel,
+    encourageMe,
     dismissToast,
   }
 }

--- a/tests/e2e/encourage-me.spec.js
+++ b/tests/e2e/encourage-me.spec.js
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+import { energyButton, encourageButton, toast } from './helpers.js'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+})
+
+test('shows an encouraging toast when clicked with no energy level selected', async ({ page }) => {
+  await expect(toast(page)).toHaveCount(0)
+
+  await encourageButton(page).click()
+
+  await expect(toast(page)).toBeVisible()
+  await expect(toast(page)).not.toBeEmpty()
+  for (const label of ['Low', 'Medium', 'High']) {
+    await expect(energyButton(page, label)).toHaveAttribute('aria-pressed', 'false')
+  }
+})
+
+test('does not change the currently selected energy level', async ({ page }) => {
+  await energyButton(page, 'Medium').click()
+  await expect(energyButton(page, 'Medium')).toHaveAttribute('aria-pressed', 'true')
+
+  await encourageButton(page).click()
+
+  await expect(energyButton(page, 'Medium')).toHaveAttribute('aria-pressed', 'true')
+  await expect(toast(page)).toBeVisible()
+})
+
+test('replaces a currently-showing energy-level toast', async ({ page }) => {
+  await energyButton(page, 'High').click()
+  await expect(toast(page)).toBeVisible()
+
+  await encourageButton(page).click()
+
+  await expect(toast(page)).toBeVisible()
+  await expect(toast(page)).not.toBeEmpty()
+})
+
+test('selecting an energy level afterwards replaces the encouragement toast', async ({ page }) => {
+  await encourageButton(page).click()
+  await expect(toast(page)).toBeVisible()
+
+  await energyButton(page, 'Low').click()
+
+  await expect(energyButton(page, 'Low')).toHaveAttribute('aria-pressed', 'true')
+  await expect(toast(page)).toBeVisible()
+})
+
+test('the toast can be dismissed manually', async ({ page }) => {
+  await encourageButton(page).click()
+  await expect(toast(page)).toBeVisible()
+
+  await page.getByRole('button', { name: 'Dismiss' }).click()
+
+  await expect(toast(page)).toHaveCount(0)
+})
+
+test('the toast disappears on its own after a few seconds', async ({ page }) => {
+  await encourageButton(page).click()
+  await expect(toast(page)).toBeVisible()
+
+  await expect(toast(page)).toHaveCount(0, { timeout: 8000 })
+})
+
+test('clicking again while a toast is showing keeps the toast visible', async ({ page }) => {
+  await encourageButton(page).click()
+  await expect(toast(page)).toBeVisible()
+
+  await encourageButton(page).click()
+
+  await expect(toast(page)).toBeVisible()
+  await expect(toast(page)).not.toBeEmpty()
+})

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -5,3 +5,7 @@ export function energyButton(page, label) {
 export function toast(page) {
   return page.getByRole('status')
 }
+
+export function encourageButton(page) {
+  return page.getByRole('button', { name: 'Encourage me', exact: true })
+}

--- a/tests/unit/energy-level/components.test.js
+++ b/tests/unit/energy-level/components.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { ref } from 'vue'
 import EnergySelector from '../../../src/components/EnergySelector.vue'
+import EncourageButton from '../../../src/components/EncourageButton.vue'
 import ToastNotification from '../../../src/components/ToastNotification.vue'
 import App from '../../../src/App.vue'
 
@@ -11,6 +12,7 @@ const state = {
   toastId: ref(0),
   selectLevel: vi.fn(),
   dismissToast: vi.fn(),
+  encourageMe: vi.fn(),
 }
 
 vi.mock('../../../src/composables/useEnergyLevel.js', () => ({
@@ -31,6 +33,7 @@ beforeEach(() => {
   state.toastId.value = 0
   state.selectLevel.mockReset()
   state.dismissToast.mockReset()
+  state.encourageMe.mockReset()
 })
 
 afterEach(() => {
@@ -74,6 +77,21 @@ describe('EnergySelector', () => {
     wrapper.findAll('button').forEach((button) => {
       expect(button.attributes('aria-pressed')).toBe('false')
     })
+  })
+})
+
+describe('EncourageButton', () => {
+  it('renders a button labeled "Encourage me"', () => {
+    const wrapper = mountTracked(EncourageButton)
+    expect(wrapper.find('button').text()).toBe('Encourage me')
+  })
+
+  it('calls encourageMe when clicked', async () => {
+    const wrapper = mountTracked(EncourageButton)
+
+    await wrapper.find('button').trigger('click')
+
+    expect(state.encourageMe).toHaveBeenCalled()
   })
 })
 
@@ -157,12 +175,22 @@ describe('ToastNotification', () => {
 })
 
 describe('App', () => {
-  it('renders the energy selector and toast notification alongside the logo and tagline', () => {
+  it('renders the energy selector, encourage button, and toast notification alongside the logo and tagline', () => {
     const wrapper = mountTracked(App)
 
     expect(wrapper.findComponent(EnergySelector).exists()).toBe(true)
+    expect(wrapper.findComponent(EncourageButton).exists()).toBe(true)
     expect(wrapper.findComponent(ToastNotification).exists()).toBe(true)
     expect(wrapper.find('h1').text()).toBe('Untangle')
     expect(wrapper.find('.tagline').text()).toBe('Space to think')
+  })
+
+  it('places the encourage button immediately to the right of the energy selector', () => {
+    const wrapper = mountTracked(App)
+    const actions = wrapper.find('.header-actions')
+    const childClasses = Array.from(actions.element.children).map((el) => el.className)
+
+    expect(childClasses[0]).toContain('energy-panel')
+    expect(childClasses[1]).toContain('encourage-button')
   })
 })

--- a/tests/unit/energy-level/composable.test.js
+++ b/tests/unit/energy-level/composable.test.js
@@ -116,4 +116,82 @@ describe('useEnergyLevel', () => {
 
     expect(second.selectedLevel.value).toBe('high')
   })
+
+  describe('encourageMe', () => {
+    it('exposes exactly 50 unique, non-empty messages', async () => {
+      const mod = await import(modulePath)
+      expect(mod.ENCOURAGEMENT_MESSAGES).toHaveLength(50)
+      expect(new Set(mod.ENCOURAGEMENT_MESSAGES).size).toBe(50)
+      mod.ENCOURAGEMENT_MESSAGES.forEach((message) => {
+        expect(typeof message).toBe('string')
+        expect(message.length).toBeGreaterThan(0)
+      })
+    })
+
+    it('shows a toast message drawn from the encouragement pool', async () => {
+      const mod = await import(modulePath)
+      const { toastMessage, encourageMe } = mod.useEnergyLevel()
+
+      encourageMe()
+
+      expect(mod.ENCOURAGEMENT_MESSAGES).toContain(toastMessage.value)
+    })
+
+    it('selects a message at random rather than always showing the same one', async () => {
+      const { toastMessage, encourageMe } = await load()
+      const seen = new Set()
+      for (let i = 0; i < 40; i++) {
+        encourageMe()
+        seen.add(toastMessage.value)
+      }
+      expect(seen.size).toBeGreaterThan(1)
+    })
+
+    it('does not select or require any energy level', async () => {
+      const { selectedLevel, encourageMe } = await load()
+
+      encourageMe()
+
+      expect(selectedLevel.value).toBe(null)
+    })
+
+    it('leaves an already-selected energy level untouched', async () => {
+      const { selectedLevel, selectLevel, encourageMe } = await load()
+      selectLevel('medium')
+
+      encourageMe()
+
+      expect(selectedLevel.value).toBe('medium')
+    })
+
+    it('fires a new toast even while a toast is already showing', async () => {
+      const { toastId, encourageMe } = await load()
+      encourageMe()
+      const firstToastId = toastId.value
+
+      encourageMe()
+
+      expect(toastId.value).toBeGreaterThan(firstToastId)
+    })
+
+    it('replaces a currently-showing energy-level toast', async () => {
+      const mod = await import(modulePath)
+      const { toastMessage, selectLevel, encourageMe } = mod.useEnergyLevel()
+      selectLevel('high')
+
+      encourageMe()
+
+      expect(mod.ENCOURAGEMENT_MESSAGES).toContain(toastMessage.value)
+    })
+
+    it('selecting an energy level after encouragement replaces the encouragement toast', async () => {
+      const mod = await import(modulePath)
+      const { toastMessage, selectLevel, encourageMe } = mod.useEnergyLevel()
+      encourageMe()
+
+      selectLevel('low')
+
+      expect(mod.LOW_MESSAGES).toContain(toastMessage.value)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Adds a standalone "Encourage me" button next to the energy-level selector; clicking it shows a random encouraging toast drawn from a new 50-message pool, reusing the existing `useEnergyLevel` toast state/behavior.
- Groups the Low/Medium/High buttons into a labeled "Energy level" panel (background + border) so they read as a unit, visually separate from the new button — added per manual-testing feedback.

## Requirement
Add an "Encourage me" button to the right of the energy selector. Clicking it displays an encouraging toast message selected at random from a pool of 50 messages, independent of any energy-level selection.

## Test plan
- [x] Unit tests: `npm test -- run` (43 passing)
- [x] E2E tests: `npm run test:e2e` (16 passing, including a11y)
- [x] Manual testing confirmed by requester

Fixes #88