### PR TITLE
Optimise Untangle for mobile usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ All task state lives in `src/composables/useTasks.js` — a module-level singlet
 
 Components are thin: they call composable functions and render results. Business logic stays in composables.
 
+The header, energy panel, Encourage me button, and toast are mobile-responsive: a `@media (max-width: 640px)` block in each component's scoped `<style>` stacks the header vertically, gives interactive controls a ~44px minimum tap target, and keeps the toast within the viewport with its close button pinned to the right edge (`justify-content: space-between`, since the toast's explicit mobile `width` is usually wider than its content). Follow the same `<=640px` breakpoint and pattern for any new interactive UI.
+
 ## Test organisation
 
 Unit tests in `tests/unit/<feature>/` always come in pairs:

--- a/src/App.vue
+++ b/src/App.vue
@@ -89,9 +89,6 @@ h1 {
 @media (max-width: 640px) {
   .brand {
     position: static;
-    top: auto;
-    left: auto;
-    right: auto;
     flex-direction: column;
     align-items: stretch;
     padding: 1.5rem 1.5rem 1rem;

--- a/src/App.vue
+++ b/src/App.vue
@@ -85,4 +85,22 @@ h1 {
   align-items: center;
   gap: 0.5rem;
 }
+
+@media (max-width: 640px) {
+  .brand {
+    position: static;
+    top: auto;
+    left: auto;
+    right: auto;
+    flex-direction: column;
+    align-items: stretch;
+    padding: 1.5rem 1.5rem 1rem;
+  }
+
+  .header-actions {
+    width: 100%;
+    flex-wrap: wrap;
+    margin-top: 0.75rem;
+  }
+}
 </style>

--- a/src/components/EncourageButton.vue
+++ b/src/components/EncourageButton.vue
@@ -27,4 +27,11 @@ const { encourageMe } = useEnergyLevel()
 .encourage-button:hover {
   border-color: #a8a8a8;
 }
+
+@media (max-width: 640px) {
+  .encourage-button {
+    min-height: 44px;
+    padding: 0.6rem 1rem;
+  }
+}
 </style>

--- a/src/components/EnergySelector.vue
+++ b/src/components/EnergySelector.vue
@@ -81,4 +81,12 @@ const { selectedLevel, selectLevel } = useEnergyLevel()
   border-color: #1a1a1a;
   color: #fff;
 }
+
+@media (max-width: 640px) {
+  .energy-option {
+    min-height: 44px;
+    min-width: 44px;
+    padding: 0.6rem 1rem;
+  }
+}
 </style>

--- a/src/components/ToastNotification.vue
+++ b/src/components/ToastNotification.vue
@@ -79,4 +79,19 @@ function handleClose() {
   padding: 0;
   flex-shrink: 0;
 }
+
+@media (max-width: 640px) {
+  .toast {
+    width: calc(100% - 2rem);
+    max-width: calc(100% - 2rem);
+  }
+
+  .toast-close {
+    min-height: 44px;
+    min-width: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
 </style>

--- a/src/components/ToastNotification.vue
+++ b/src/components/ToastNotification.vue
@@ -83,6 +83,7 @@ function handleClose() {
 @media (max-width: 640px) {
   .toast {
     width: calc(100% - 2rem);
+    box-sizing: border-box;
   }
 
   .toast-close {

--- a/src/components/ToastNotification.vue
+++ b/src/components/ToastNotification.vue
@@ -83,7 +83,6 @@ function handleClose() {
 @media (max-width: 640px) {
   .toast {
     width: calc(100% - 2rem);
-    max-width: calc(100% - 2rem);
   }
 
   .toast-close {

--- a/src/components/ToastNotification.vue
+++ b/src/components/ToastNotification.vue
@@ -84,6 +84,7 @@ function handleClose() {
   .toast {
     width: calc(100% - 2rem);
     box-sizing: border-box;
+    justify-content: space-between;
   }
 
   .toast-close {

--- a/tests/e2e/mobile-responsive.spec.js
+++ b/tests/e2e/mobile-responsive.spec.js
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+import { energyButton, encourageButton, toast } from './helpers.js'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+})
+
+test.describe('mobile viewport (375x812)', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+
+  test('stacks the header vertically instead of side-by-side', async ({ page }) => {
+    const brandBox = await page.locator('.brand-text').boundingBox()
+    const actionsBox = await page.locator('.header-actions').boundingBox()
+
+    expect(actionsBox.y).toBeGreaterThan(brandBox.y + brandBox.height)
+  })
+
+  test('keeps the header actions within the viewport width', async ({ page }) => {
+    const actionsBox = await page.locator('.header-actions').boundingBox()
+
+    expect(actionsBox.x + actionsBox.width).toBeLessThanOrEqual(375)
+  })
+
+  test('gives energy-level buttons and the Encourage me button a 44px minimum tap target', async ({
+    page,
+  }) => {
+    for (const label of ['Low', 'Medium', 'High']) {
+      const box = await energyButton(page, label).boundingBox()
+      expect(box.height).toBeGreaterThanOrEqual(44)
+    }
+
+    const encourageBox = await encourageButton(page).boundingBox()
+    expect(encourageBox.height).toBeGreaterThanOrEqual(44)
+  })
+
+  test('keeps the toast within the viewport and gives its close button a 44px tap target', async ({
+    page,
+  }) => {
+    await energyButton(page, 'Low').click()
+    await expect(toast(page)).toBeVisible()
+
+    const toastBox = await toast(page).boundingBox()
+    expect(toastBox.x).toBeGreaterThanOrEqual(0)
+    expect(toastBox.x + toastBox.width).toBeLessThanOrEqual(375)
+
+    const closeBox = await page.getByRole('button', { name: 'Dismiss' }).boundingBox()
+    expect(closeBox.height).toBeGreaterThanOrEqual(44)
+    expect(closeBox.width).toBeGreaterThanOrEqual(44)
+  })
+})
+
+test.describe('desktop viewport (unchanged above 640px)', () => {
+  test('keeps the header actions on the same row as the logo', async ({ page }) => {
+    const brandBox = await page.locator('.brand-text').boundingBox()
+    const actionsBox = await page.locator('.header-actions').boundingBox()
+
+    expect(Math.abs(actionsBox.y - brandBox.y)).toBeLessThan(20)
+  })
+})

--- a/tests/e2e/mobile-responsive.spec.js
+++ b/tests/e2e/mobile-responsive.spec.js
@@ -48,6 +48,9 @@ test.describe('mobile viewport (375x812)', () => {
     const closeBox = await page.getByRole('button', { name: 'Dismiss' }).boundingBox()
     expect(closeBox.height).toBeGreaterThanOrEqual(44)
     expect(closeBox.width).toBeGreaterThanOrEqual(44)
+
+    const justifyContent = await toast(page).evaluate((el) => getComputedStyle(el).justifyContent)
+    expect(justifyContent).toBe('space-between')
   })
 })
 

--- a/tests/e2e/mobile-responsive.spec.js
+++ b/tests/e2e/mobile-responsive.spec.js
@@ -42,8 +42,8 @@ test.describe('mobile viewport (375x812)', () => {
     await expect(toast(page)).toBeVisible()
 
     const toastBox = await toast(page).boundingBox()
-    expect(toastBox.x).toBeGreaterThanOrEqual(0)
-    expect(toastBox.x + toastBox.width).toBeLessThanOrEqual(375)
+    expect(toastBox.x).toBeGreaterThan(8)
+    expect(375 - (toastBox.x + toastBox.width)).toBeGreaterThan(8)
 
     const closeBox = await page.getByRole('button', { name: 'Dismiss' }).boundingBox()
     expect(closeBox.height).toBeGreaterThanOrEqual(44)


### PR DESCRIPTION
## Summary
- At viewport widths <=640px, the header (logo/tagline, energy-level panel, Encourage me button) stacks vertically instead of sitting in a single row, so nothing overflows or crowds on phone screens.
- Interactive controls (energy-level buttons, Encourage me button, toast close button) get a ~44px minimum tap target at mobile widths.
- The toast notification stays fully within the viewport with real side margins, and its close button is pinned to the right edge.
- Above 640px, the desktop layout is unchanged (CSS media queries only, additive).

## Bugs found and fixed along the way
- #91 — toast touched both viewport edges with zero margin (content-box padding was adding on top of the calc()-based width).
- #92 — toast close button floated with a large empty gap instead of sitting at the right edge (missing `justify-content: space-between`), reported during manual testing.

## Test plan
- [x] `npx vitest run` — 43 unit tests pass (no unit-level changes needed; this is a CSS-only change with no new composable/component logic — jsdom doesn't evaluate media queries anyway)
- [x] `npm run test:e2e` — 21 e2e tests pass, including a new `tests/e2e/mobile-responsive.spec.js` covering header stacking, tap targets, toast containment/margins, and a desktop-unchanged guard
- [x] Manually verified in browser at 375px width and confirmed by the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)