### PR TITLE
Add Tough love button alongside Encourage me

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,16 +152,16 @@ To trigger a wiki review outside the deploy workflow (e.g. after a direct wiki e
 
 ## Key files
 
-| File                                 | Purpose                                                                            |
-| ------------------------------------ | ---------------------------------------------------------------------------------- |
-| `src/composables/useTasks.js`        | Task logic, energy filtering, localStorage persistence                             |
+| File                                 | Purpose                                                                                    |
+| ------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `src/composables/useTasks.js`        | Task logic, energy filtering, localStorage persistence                                     |
 | `src/composables/useEnergyLevel.js`  | Header energy-level selection state, "Encourage me"/"Tough love" toasts, and message pools |
-| `scripts/workflow-state.mjs`         | 14-stage pipeline state machine (`start`/`get`/`set`/`approve`/`loopback`/`reset`) |
-| `scripts/bug-tracker.mjs`            | CLI for creating/closing GitHub bug issues, category list                          |
-| `scripts/check-docs.mjs`             | CI documentation-check job                                                         |
-| `scripts/pre-push-check.mjs`         | `pre-push` git hook logic (blocks direct `main` pushes, checks sign-off)           |
-| `scripts/post-commit-close-bugs.mjs` | `post-commit` git hook logic (auto-closes bugs via commit trailers)                |
-| `.claude/skills/`                    | The 14 pipeline skills plus `report-bug` and `wiki-update`                         |
-| `.github/workflows/ci.yml`           | The 9-job CI pipeline                                                              |
-| `.github/workflows/deploy-pages.yml` | Builds and publishes `main` to GitHub Pages after merge                            |
-| `reports/`                           | Post-deploy change reports, one markdown file per merged change                    |
+| `scripts/workflow-state.mjs`         | 14-stage pipeline state machine (`start`/`get`/`set`/`approve`/`loopback`/`reset`)         |
+| `scripts/bug-tracker.mjs`            | CLI for creating/closing GitHub bug issues, category list                                  |
+| `scripts/check-docs.mjs`             | CI documentation-check job                                                                 |
+| `scripts/pre-push-check.mjs`         | `pre-push` git hook logic (blocks direct `main` pushes, checks sign-off)                   |
+| `scripts/post-commit-close-bugs.mjs` | `post-commit` git hook logic (auto-closes bugs via commit trailers)                        |
+| `.claude/skills/`                    | The 14 pipeline skills plus `report-bug` and `wiki-update`                                 |
+| `.github/workflows/ci.yml`           | The 9-job CI pipeline                                                                      |
+| `.github/workflows/deploy-pages.yml` | Builds and publishes `main` to GitHub Pages after merge                                    |
+| `reports/`                           | Post-deploy change reports, one markdown file per merged change                            |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,11 @@ npm run test:e2e        # end-to-end tests (Playwright, requires dev/build+previ
 
 All task state lives in `src/composables/useTasks.js` — a module-level singleton (Vue reactive refs outside the function). Every component that calls `useTasks()` shares the same state. Follow the same singleton pattern for any other cross-component state.
 
-`src/composables/useEnergyLevel.js` follows the same singleton pattern for the header's energy-level selector (`src/components/EnergySelector.vue`, grouped in its own labeled panel), the standalone "Encourage me" button (`src/components/EncourageButton.vue`), and their shared toast notification (`src/components/ToastNotification.vue`): selecting a Low/Medium/High level picks a random encouraging message from a 20-message-per-level pool, and the "Encourage me" button picks one from a separate 50-message general pool, either way showing it as a toast that auto-dismisses after a few seconds or can be closed manually. Selection is in-memory only and always resets to "none" on reload.
+`src/composables/useEnergyLevel.js` follows the same singleton pattern for the header's energy-level selector (`src/components/EnergySelector.vue`, grouped in its own labeled panel), the standalone "Encourage me" and "Tough love" buttons (`src/components/EncourageButton.vue`, `src/components/ToughLoveButton.vue`), and their shared toast notification (`src/components/ToastNotification.vue`): selecting a Low/Medium/High level picks a random encouraging message from a 20-message-per-level pool, the "Encourage me" button picks one from a separate 50-message general pool, and the "Tough love" button picks one from its own separate 50-message pool of firmer, more pressing (but not harsh or shaming) messages — either way showing it as a toast that auto-dismisses after a few seconds or can be closed manually. Selection is in-memory only and always resets to "none" on reload.
 
 Components are thin: they call composable functions and render results. Business logic stays in composables.
 
-The header, energy panel, Encourage me button, and toast are mobile-responsive: a `@media (max-width: 640px)` block in each component's scoped `<style>` stacks the header vertically, gives interactive controls a ~44px minimum tap target, and keeps the toast within the viewport with its close button pinned to the right edge (`justify-content: space-between`, since the toast's explicit mobile `width` is usually wider than its content). Follow the same `<=640px` breakpoint and pattern for any new interactive UI.
+The header, energy panel, Encourage me button, Tough love button, and toast are mobile-responsive: a `@media (max-width: 640px)` block in each component's scoped `<style>` stacks the header vertically, gives interactive controls a ~44px minimum tap target, and keeps the toast within the viewport with its close button pinned to the right edge (`justify-content: space-between`, since the toast's explicit mobile `width` is usually wider than its content). Follow the same `<=640px` breakpoint and pattern for any new interactive UI.
 
 ## Test organisation
 
@@ -155,7 +155,7 @@ To trigger a wiki review outside the deploy workflow (e.g. after a direct wiki e
 | File                                 | Purpose                                                                            |
 | ------------------------------------ | ---------------------------------------------------------------------------------- |
 | `src/composables/useTasks.js`        | Task logic, energy filtering, localStorage persistence                             |
-| `src/composables/useEnergyLevel.js`  | Header energy-level selection state, "Encourage me" toast, and message pools       |
+| `src/composables/useEnergyLevel.js`  | Header energy-level selection state, "Encourage me"/"Tough love" toasts, and message pools |
 | `scripts/workflow-state.mjs`         | 14-stage pipeline state machine (`start`/`get`/`set`/`approve`/`loopback`/`reset`) |
 | `scripts/bug-tracker.mjs`            | CLI for creating/closing GitHub bug issues, category list                          |
 | `scripts/check-docs.mjs`             | CI documentation-check job                                                         |

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <script setup>
 import EnergySelector from './components/EnergySelector.vue'
 import EncourageButton from './components/EncourageButton.vue'
+import ToughLoveButton from './components/ToughLoveButton.vue'
 import ToastNotification from './components/ToastNotification.vue'
 </script>
 
@@ -31,6 +32,7 @@ import ToastNotification from './components/ToastNotification.vue'
       <div class="header-actions">
         <EnergySelector />
         <EncourageButton />
+        <ToughLoveButton />
       </div>
     </header>
     <ToastNotification />

--- a/src/components/ToughLoveButton.vue
+++ b/src/components/ToughLoveButton.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { useEnergyLevel } from '../composables/useEnergyLevel.js'
+
+const { toughLove } = useEnergyLevel()
+</script>
+
+<template>
+  <button type="button" class="tough-love-button" @click="toughLove">Tough love</button>
+</template>
+
+<style scoped>
+.tough-love-button {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid #d6d6d6;
+  background: #fff;
+  color: #1a1a1a;
+  cursor: pointer;
+}
+
+.tough-love-button:hover {
+  border-color: #a8a8a8;
+}
+
+@media (max-width: 640px) {
+  .tough-love-button {
+    min-height: 44px;
+    padding: 0.6rem 1rem;
+  }
+}
+</style>

--- a/src/composables/useEnergyLevel.js
+++ b/src/composables/useEnergyLevel.js
@@ -122,6 +122,59 @@ export const ENCOURAGEMENT_MESSAGES = [
   "You've got what it takes to keep moving.",
 ]
 
+export const TOUGH_LOVE_MESSAGES = [
+  'Stop waiting to feel ready. Start anyway.',
+  'You already know what to do. Go do it.',
+  'Excuses are just decisions in disguise. Choose again.',
+  "The task isn't getting smaller by staring at it.",
+  'Perfect conditions are a myth. Move now.',
+  "You've stalled long enough. Pick it up.",
+  "Motivation isn't coming to save you. Discipline is.",
+  'Comfort got you here. It will not get you further.',
+  'Nobody is coming to do this for you.',
+  'Stop negotiating with yourself and just begin.',
+  'One more delay is one more excuse you will regret.',
+  'You are capable of more than this hesitation suggests.',
+  'Feelings are not instructions. Act despite them.',
+  'The version of you tomorrow needs you to move today.',
+  'Quit rehearsing the task and actually start it.',
+  'You do not need permission to get started.',
+  'Every minute spent stalling is a minute wasted.',
+  'Being tired is not the same as being unable.',
+  "This won't finish itself. Get moving.",
+  'You owe yourself better than another day of avoidance.',
+  'Stop scrolling. Start doing.',
+  'The hard part is starting, and you are still not starting.',
+  "You've had enough time to think. Now act.",
+  'Nobody is impressed by intentions. Show results.',
+  'Discomfort is not a stop sign. Push through it.',
+  'You are not stuck, you are stalling.',
+  'Stop waiting for a sign. This is it.',
+  'Cut the excuses and get to work.',
+  "You've survived every hard day before this one. Get on with it.",
+  'Small effort now beats big regret later.',
+  'Enough deliberating. Decide and move.',
+  'You are the only thing standing between you and this task.',
+  'Quit circling the task and land on it.',
+  'This is not the time to be gentle with your excuses.',
+  "You don't feel like it. Do it anyway.",
+  'Waiting for motivation is a losing strategy. Start without it.',
+  'You know the cost of not doing this. Act accordingly.',
+  'Stop planning to start and actually start.',
+  'The task is not going to get easier by delaying it.',
+  'You have what it takes. Use it now.',
+  'Nobody remembers your reasons, only your results.',
+  'You are better than this pattern of putting it off.',
+  'Get uncomfortable. That is where progress lives.',
+  'You keep saying later. Make it now.',
+  'This hesitation is costing you more than the task would.',
+  'Stand up and do the thing you are avoiding.',
+  'Your future self is watching what you choose right now.',
+  'Enough with the warm-up. Get to the real work.',
+  'You do not need more time, you need to start.',
+  'Move first, feel better second. That is the order.',
+]
+
 const MESSAGE_POOLS = {
   low: LOW_MESSAGES,
   medium: MEDIUM_MESSAGES,
@@ -152,6 +205,11 @@ function encourageMe() {
   toastId.value += 1
 }
 
+function toughLove() {
+  toastMessage.value = randomFrom(TOUGH_LOVE_MESSAGES)
+  toastId.value += 1
+}
+
 function dismissToast() {
   toastMessage.value = null
 }
@@ -163,6 +221,7 @@ export function useEnergyLevel() {
     toastId,
     selectLevel,
     encourageMe,
+    toughLove,
     dismissToast,
   }
 }

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -9,3 +9,7 @@ export function toast(page) {
 export function encourageButton(page) {
   return page.getByRole('button', { name: 'Encourage me', exact: true })
 }
+
+export function toughLoveButton(page) {
+  return page.getByRole('button', { name: 'Tough love', exact: true })
+}

--- a/tests/e2e/mobile-responsive.spec.js
+++ b/tests/e2e/mobile-responsive.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { energyButton, encourageButton, toast } from './helpers.js'
+import { energyButton, encourageButton, toughLoveButton, toast } from './helpers.js'
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/')
@@ -23,7 +23,7 @@ test.describe('mobile viewport (375x812)', () => {
     expect(actionsBox.x + actionsBox.width).toBeLessThanOrEqual(375)
   })
 
-  test('gives energy-level buttons and the Encourage me button a 44px minimum tap target', async ({
+  test('gives energy-level buttons, the Encourage me button, and the Tough love button a 44px minimum tap target', async ({
     page,
   }) => {
     for (const label of ['Low', 'Medium', 'High']) {
@@ -33,6 +33,9 @@ test.describe('mobile viewport (375x812)', () => {
 
     const encourageBox = await encourageButton(page).boundingBox()
     expect(encourageBox.height).toBeGreaterThanOrEqual(44)
+
+    const toughLoveBox = await toughLoveButton(page).boundingBox()
+    expect(toughLoveBox.height).toBeGreaterThanOrEqual(44)
   })
 
   test('keeps the toast within the viewport and gives its close button a 44px tap target', async ({

--- a/tests/e2e/tough-love.spec.js
+++ b/tests/e2e/tough-love.spec.js
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+import { energyButton, toughLoveButton, toast } from './helpers.js'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+})
+
+test('shows a tough-love toast when clicked with no energy level selected', async ({ page }) => {
+  await expect(toast(page)).toHaveCount(0)
+
+  await toughLoveButton(page).click()
+
+  await expect(toast(page)).toBeVisible()
+  await expect(toast(page)).not.toBeEmpty()
+  for (const label of ['Low', 'Medium', 'High']) {
+    await expect(energyButton(page, label)).toHaveAttribute('aria-pressed', 'false')
+  }
+})
+
+test('does not change the currently selected energy level', async ({ page }) => {
+  await energyButton(page, 'Medium').click()
+  await expect(energyButton(page, 'Medium')).toHaveAttribute('aria-pressed', 'true')
+
+  await toughLoveButton(page).click()
+
+  await expect(energyButton(page, 'Medium')).toHaveAttribute('aria-pressed', 'true')
+  await expect(toast(page)).toBeVisible()
+})
+
+test('replaces a currently-showing energy-level toast', async ({ page }) => {
+  await energyButton(page, 'High').click()
+  await expect(toast(page)).toBeVisible()
+
+  await toughLoveButton(page).click()
+
+  await expect(toast(page)).toBeVisible()
+  await expect(toast(page)).not.toBeEmpty()
+})
+
+test('selecting an energy level afterwards replaces the tough-love toast', async ({ page }) => {
+  await toughLoveButton(page).click()
+  await expect(toast(page)).toBeVisible()
+
+  await energyButton(page, 'Low').click()
+
+  await expect(energyButton(page, 'Low')).toHaveAttribute('aria-pressed', 'true')
+  await expect(toast(page)).toBeVisible()
+})
+
+test('the toast can be dismissed manually', async ({ page }) => {
+  await toughLoveButton(page).click()
+  await expect(toast(page)).toBeVisible()
+
+  await page.getByRole('button', { name: 'Dismiss' }).click()
+
+  await expect(toast(page)).toHaveCount(0)
+})
+
+test('the toast disappears on its own after a few seconds', async ({ page }) => {
+  await toughLoveButton(page).click()
+  await expect(toast(page)).toBeVisible()
+
+  await expect(toast(page)).toHaveCount(0, { timeout: 8000 })
+})
+
+test('clicking again while a toast is showing keeps the toast visible', async ({ page }) => {
+  await toughLoveButton(page).click()
+  await expect(toast(page)).toBeVisible()
+
+  await toughLoveButton(page).click()
+
+  await expect(toast(page)).toBeVisible()
+  await expect(toast(page)).not.toBeEmpty()
+})

--- a/tests/unit/energy-level/components.test.js
+++ b/tests/unit/energy-level/components.test.js
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils'
 import { ref } from 'vue'
 import EnergySelector from '../../../src/components/EnergySelector.vue'
 import EncourageButton from '../../../src/components/EncourageButton.vue'
+import ToughLoveButton from '../../../src/components/ToughLoveButton.vue'
 import ToastNotification from '../../../src/components/ToastNotification.vue'
 import App from '../../../src/App.vue'
 
@@ -13,6 +14,7 @@ const state = {
   selectLevel: vi.fn(),
   dismissToast: vi.fn(),
   encourageMe: vi.fn(),
+  toughLove: vi.fn(),
 }
 
 vi.mock('../../../src/composables/useEnergyLevel.js', () => ({
@@ -34,6 +36,7 @@ beforeEach(() => {
   state.selectLevel.mockReset()
   state.dismissToast.mockReset()
   state.encourageMe.mockReset()
+  state.toughLove.mockReset()
 })
 
 afterEach(() => {
@@ -92,6 +95,21 @@ describe('EncourageButton', () => {
     await wrapper.find('button').trigger('click')
 
     expect(state.encourageMe).toHaveBeenCalled()
+  })
+})
+
+describe('ToughLoveButton', () => {
+  it('renders a button labeled "Tough love"', () => {
+    const wrapper = mountTracked(ToughLoveButton)
+    expect(wrapper.find('button').text()).toBe('Tough love')
+  })
+
+  it('calls toughLove when clicked', async () => {
+    const wrapper = mountTracked(ToughLoveButton)
+
+    await wrapper.find('button').trigger('click')
+
+    expect(state.toughLove).toHaveBeenCalled()
   })
 })
 
@@ -175,22 +193,24 @@ describe('ToastNotification', () => {
 })
 
 describe('App', () => {
-  it('renders the energy selector, encourage button, and toast notification alongside the logo and tagline', () => {
+  it('renders the energy selector, encourage button, tough love button, and toast notification alongside the logo and tagline', () => {
     const wrapper = mountTracked(App)
 
     expect(wrapper.findComponent(EnergySelector).exists()).toBe(true)
     expect(wrapper.findComponent(EncourageButton).exists()).toBe(true)
+    expect(wrapper.findComponent(ToughLoveButton).exists()).toBe(true)
     expect(wrapper.findComponent(ToastNotification).exists()).toBe(true)
     expect(wrapper.find('h1').text()).toBe('Untangle')
     expect(wrapper.find('.tagline').text()).toBe('Space to think')
   })
 
-  it('places the encourage button immediately to the right of the energy selector', () => {
+  it('places the encourage button immediately to the right of the energy selector, and the tough love button after that', () => {
     const wrapper = mountTracked(App)
     const actions = wrapper.find('.header-actions')
     const childClasses = Array.from(actions.element.children).map((el) => el.className)
 
     expect(childClasses[0]).toContain('energy-panel')
     expect(childClasses[1]).toContain('encourage-button')
+    expect(childClasses[2]).toContain('tough-love-button')
   })
 })

--- a/tests/unit/energy-level/composable.test.js
+++ b/tests/unit/energy-level/composable.test.js
@@ -194,4 +194,92 @@ describe('useEnergyLevel', () => {
       expect(mod.LOW_MESSAGES).toContain(toastMessage.value)
     })
   })
+
+  describe('toughLove', () => {
+    it('exposes exactly 50 unique, non-empty messages', async () => {
+      const mod = await import(modulePath)
+      expect(mod.TOUGH_LOVE_MESSAGES).toHaveLength(50)
+      expect(new Set(mod.TOUGH_LOVE_MESSAGES).size).toBe(50)
+      mod.TOUGH_LOVE_MESSAGES.forEach((message) => {
+        expect(typeof message).toBe('string')
+        expect(message.length).toBeGreaterThan(0)
+      })
+    })
+
+    it('shows a toast message drawn from the tough love pool', async () => {
+      const mod = await import(modulePath)
+      const { toastMessage, toughLove } = mod.useEnergyLevel()
+
+      toughLove()
+
+      expect(mod.TOUGH_LOVE_MESSAGES).toContain(toastMessage.value)
+    })
+
+    it('selects a message at random rather than always showing the same one', async () => {
+      const { toastMessage, toughLove } = await load()
+      const seen = new Set()
+      for (let i = 0; i < 40; i++) {
+        toughLove()
+        seen.add(toastMessage.value)
+      }
+      expect(seen.size).toBeGreaterThan(1)
+    })
+
+    it('does not select or require any energy level', async () => {
+      const { selectedLevel, toughLove } = await load()
+
+      toughLove()
+
+      expect(selectedLevel.value).toBe(null)
+    })
+
+    it('leaves an already-selected energy level untouched', async () => {
+      const { selectedLevel, selectLevel, toughLove } = await load()
+      selectLevel('medium')
+
+      toughLove()
+
+      expect(selectedLevel.value).toBe('medium')
+    })
+
+    it('fires a new toast even while a toast is already showing', async () => {
+      const { toastId, toughLove } = await load()
+      toughLove()
+      const firstToastId = toastId.value
+
+      toughLove()
+
+      expect(toastId.value).toBeGreaterThan(firstToastId)
+    })
+
+    it('replaces a currently-showing energy-level toast', async () => {
+      const mod = await import(modulePath)
+      const { toastMessage, selectLevel, toughLove } = mod.useEnergyLevel()
+      selectLevel('high')
+
+      toughLove()
+
+      expect(mod.TOUGH_LOVE_MESSAGES).toContain(toastMessage.value)
+    })
+
+    it('selecting an energy level after tough love replaces the tough love toast', async () => {
+      const mod = await import(modulePath)
+      const { toastMessage, selectLevel, toughLove } = mod.useEnergyLevel()
+      toughLove()
+
+      selectLevel('low')
+
+      expect(mod.LOW_MESSAGES).toContain(toastMessage.value)
+    })
+
+    it('replaces a currently-showing encouragement toast', async () => {
+      const mod = await import(modulePath)
+      const { toastMessage, encourageMe, toughLove } = mod.useEnergyLevel()
+      encourageMe()
+
+      toughLove()
+
+      expect(mod.TOUGH_LOVE_MESSAGES).toContain(toastMessage.value)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Adds a "Tough love" button next to the existing "Encourage me" button in the header actions.
- Reuses the existing toast/composable pattern: a new 50-message `TOUGH_LOVE_MESSAGES` pool (firmer, more pressing tone, not harsh or shaming) and a `toughLove()` function mirroring `encourageMe()`.
- New `ToughLoveButton.vue` mirrors `EncourageButton.vue` exactly, including the `<=640px` mobile tap-target styling.
- `CLAUDE.md` updated to document the new button/pool.

## Requirement
Add a Tough love button next to Encourage me. It works like Encourage me (toast, auto-dismiss/manual close) but draws from a separate pool of stronger, more pressing messages.

## Test plan
- [x] Unit tests: composable + component pairs updated (54 tests, 100% coverage)
- [x] E2E tests: new `tests/e2e/tough-love.spec.js` (7 tests) + mobile tap-target coverage extended (28 total e2e tests passing)
- [x] Manual testing: verified in browser (click shows toast, dismiss/auto-dismiss, energy-level interplay, mobile tap target)
- [x] Lint, build, coverage gate, PWA check, security audit all pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)