### PR TITLE
now-next-later

### DIFF
--- a/docs/adr/0001-non-singleton-composable-for-section-collapse.md
+++ b/docs/adr/0001-non-singleton-composable-for-section-collapse.md
@@ -1,0 +1,51 @@
+# 0001. Use a per-instance (non-singleton) composable for Now/Next/Later collapse state
+
+Status: Accepted
+Date: 2026-09-06
+
+## Context
+
+The Now/Next/Later scaffold (see `.workflow/now-next-later/requirements.md`) needs in-memory
+expand/collapse state for three fixed sections, scoped to a single parent component
+(`NowNextLaterBoard.vue`) and its three `CollapsibleSection.vue` children.
+
+The codebase's one existing precedent for cross-component state, `src/composables/useEnergyLevel.ts`,
+is a module-level singleton: refs are declared outside the exported function, so every caller
+shares one instance. That pattern exists because energy-level/toast state is read and written by
+four components (`EnergySelector`, `EncourageButton`, `ToughLoveButton`, `ToastNotification`) that
+are siblings in `App.vue`'s tree with no parent-child relationship to each other — a singleton is
+the simplest way to share that state without prop-drilling through `App.vue`.
+
+Section-collapse state has a different shape: exactly one consumer subtree
+(`NowNextLaterBoard.vue` owns the state; its three `CollapsibleSection.vue` children receive it via
+props and report interactions via an emitted event). No other component in the app needs to read or
+write it. Two options were considered:
+
+1. Follow the `useEnergyLevel` precedent literally: a module-level singleton
+   `useSectionCollapse()`.
+2. A plain (non-singleton) composable factory: each call returns a fresh set of reactive refs,
+   scoped to whichever component called it.
+
+## Decision
+
+Implement `useSectionCollapse()` as a plain factory function (option 2), called once inside
+`NowNextLaterBoard.vue`'s `<script setup>`. It is a composable — business logic still lives outside
+the component, per this codebase's "components stay thin" convention — but it is deliberately *not*
+a module-level singleton.
+
+## Consequences
+
+- Matches the actual data-sharing shape needed (single owning subtree) without introducing global
+  state that nothing outside that subtree reads.
+- Each call to `useSectionCollapse()` (including from multiple mounts in tests) gets independent
+  state. This removes the need for the `vi.resetModules()` dance that `useEnergyLevel`'s tests
+  require to get a clean singleton between test cases (see
+  `tests/unit/energy-level/composable.test.ts`); `tests/unit/now-next-later/composable.test.ts` can
+  call the factory fresh per test instead.
+- Cucumber's default World instantiation (one new World per scenario) gives BDD scenarios a fresh
+  `useSectionCollapse()` instance for free, with no explicit "reset" step needed (unlike the energy
+  World's `Given a fresh session` step, which must manually undo singleton state).
+- If a future requirement needs section-collapse state to be read or controlled from outside the
+  `NowNextLaterBoard` subtree (e.g. a global "collapse all" control living elsewhere in the header),
+  this decision should be revisited — that would be the point to promote `useSectionCollapse` to a
+  module-level singleton, matching `useEnergyLevel`'s pattern.

--- a/docs/adr/0001-non-singleton-composable-for-section-collapse.md
+++ b/docs/adr/0001-non-singleton-composable-for-section-collapse.md
@@ -30,7 +30,7 @@ write it. Two options were considered:
 
 Implement `useSectionCollapse()` as a plain factory function (option 2), called once inside
 `NowNextLaterBoard.vue`'s `<script setup>`. It is a composable — business logic still lives outside
-the component, per this codebase's "components stay thin" convention — but it is deliberately *not*
+the component, per this codebase's "components stay thin" convention — but it is deliberately _not_
 a module-level singleton.
 
 ## Consequences

--- a/features/now-next-later-sections.feature
+++ b/features/now-next-later-sections.feature
@@ -1,0 +1,37 @@
+Feature: Now / Next / Later section collapse
+  As someone using Untangle
+  I want each of the Now/Next/Later sections to collapse and expand independently
+  So I can hide sections I'm not focused on without losing track of the others
+
+  Scenario: All three sections are expanded at the start of a scenario
+    Then the "Now" section should be expanded
+    And the "Next" section should be expanded
+    And the "Later" section should be expanded
+
+  Scenario Outline: Collapsing one section leaves the other two expanded
+    When I collapse the "<section>" section
+    Then the "<section>" section should be collapsed
+    And the other sections should remain expanded
+
+    Examples:
+      | section |
+      | Now     |
+      | Next    |
+      | Later   |
+
+  Scenario Outline: Expanding a previously collapsed section restores it without affecting the others
+    Given I have collapsed the "<section>" section
+    When I expand the "<section>" section
+    Then the "<section>" section should be expanded
+    And the other sections should remain expanded
+
+    Examples:
+      | section |
+      | Now     |
+      | Next    |
+      | Later   |
+
+  Scenario: Toggling a section twice returns it to its original expanded state
+    When I collapse the "Now" section
+    And I expand the "Now" section
+    Then the "Now" section should be expanded

--- a/features/step_definitions/section-collapse.steps.ts
+++ b/features/step_definitions/section-collapse.steps.ts
@@ -1,0 +1,71 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import assert from 'node:assert/strict'
+import type { EnergyWorld } from '../support/world'
+import type { SectionKey } from '../../src/composables/useSectionCollapse'
+
+const SECTION_KEYS_BY_LABEL: Record<string, SectionKey> = {
+  Now: 'now',
+  Next: 'next',
+  Later: 'later',
+}
+
+function keyForLabel(label: string): SectionKey {
+  const key = SECTION_KEYS_BY_LABEL[label]
+  if (!key) {
+    throw new Error(`No section named "${label}"`)
+  }
+  return key
+}
+
+Given(
+  'I have collapsed the {string} section',
+  function (this: EnergyWorld, label: string) {
+    const key = keyForLabel(label)
+    this.sections.toggle(key)
+    this.lastToggledSectionKey = key
+  }
+)
+
+When('I collapse the {string} section', function (this: EnergyWorld, label: string) {
+  const key = keyForLabel(label)
+  this.sections.toggle(key)
+  this.lastToggledSectionKey = key
+})
+
+When('I expand the {string} section', function (this: EnergyWorld, label: string) {
+  const key = keyForLabel(label)
+  this.sections.toggle(key)
+  this.lastToggledSectionKey = key
+})
+
+Then(
+  'the {string} section should be expanded',
+  function (this: EnergyWorld, label: string) {
+    assert.equal(this.sections.expanded[keyForLabel(label)], true)
+  }
+)
+
+Then(
+  'the {string} section should be collapsed',
+  function (this: EnergyWorld, label: string) {
+    assert.equal(this.sections.expanded[keyForLabel(label)], false)
+  }
+)
+
+Then('the other sections should remain expanded', function (this: EnergyWorld) {
+  const actedOn = this.lastToggledSectionKey
+  assert.notEqual(actedOn, null, 'no section has been acted on yet in this scenario')
+
+  const otherKeys = (Object.keys(this.sections.expanded) as SectionKey[]).filter(
+    (key) => key !== actedOn
+  )
+  assert.ok(otherKeys.length > 0, 'expected at least one other section to check')
+
+  for (const key of otherKeys) {
+    assert.equal(
+      this.sections.expanded[key],
+      true,
+      `expected section "${key}" to remain expanded`
+    )
+  }
+})

--- a/features/step_definitions/section-collapse.steps.ts
+++ b/features/step_definitions/section-collapse.steps.ts
@@ -17,14 +17,11 @@ function keyForLabel(label: string): SectionKey {
   return key
 }
 
-Given(
-  'I have collapsed the {string} section',
-  function (this: EnergyWorld, label: string) {
-    const key = keyForLabel(label)
-    this.sections.toggle(key)
-    this.lastToggledSectionKey = key
-  }
-)
+Given('I have collapsed the {string} section', function (this: EnergyWorld, label: string) {
+  const key = keyForLabel(label)
+  this.sections.toggle(key)
+  this.lastToggledSectionKey = key
+})
 
 When('I collapse the {string} section', function (this: EnergyWorld, label: string) {
   const key = keyForLabel(label)
@@ -38,19 +35,13 @@ When('I expand the {string} section', function (this: EnergyWorld, label: string
   this.lastToggledSectionKey = key
 })
 
-Then(
-  'the {string} section should be expanded',
-  function (this: EnergyWorld, label: string) {
-    assert.equal(this.sections.expanded[keyForLabel(label)], true)
-  }
-)
+Then('the {string} section should be expanded', function (this: EnergyWorld, label: string) {
+  assert.equal(this.sections.expanded[keyForLabel(label)], true)
+})
 
-Then(
-  'the {string} section should be collapsed',
-  function (this: EnergyWorld, label: string) {
-    assert.equal(this.sections.expanded[keyForLabel(label)], false)
-  }
-)
+Then('the {string} section should be collapsed', function (this: EnergyWorld, label: string) {
+  assert.equal(this.sections.expanded[keyForLabel(label)], false)
+})
 
 Then('the other sections should remain expanded', function (this: EnergyWorld) {
   const actedOn = this.lastToggledSectionKey
@@ -62,10 +53,6 @@ Then('the other sections should remain expanded', function (this: EnergyWorld) {
   assert.ok(otherKeys.length > 0, 'expected at least one other section to check')
 
   for (const key of otherKeys) {
-    assert.equal(
-      this.sections.expanded[key],
-      true,
-      `expected section "${key}" to remain expanded`
-    )
+    assert.equal(this.sections.expanded[key], true, `expected section "${key}" to remain expanded`)
   }
 })

--- a/features/support/world.ts
+++ b/features/support/world.ts
@@ -1,12 +1,24 @@
 import { setWorldConstructor, World } from '@cucumber/cucumber'
 import { useEnergyLevel } from '../../src/composables/useEnergyLevel'
+import { useSectionCollapse, type SectionKey } from '../../src/composables/useSectionCollapse'
 
-// BDD scenarios drive the useEnergyLevel composable directly — the same
-// singleton components use — rather than reaching into implementation
-// details. Scenarios describe user-observable flows at a coarser grain than
-// the composable/components unit test pairs in tests/unit/energy-level/.
+// BDD scenarios drive composables directly — the same instances/singletons
+// components use — rather than reaching into implementation details.
+// Scenarios describe user-observable flows at a coarser grain than the
+// composable/components unit test pairs under tests/unit/.
+//
+// Cucumber supports only one World constructor per project, so unrelated
+// feature areas each get their own property on this same class rather than
+// a second World. `sections` is a fresh `useSectionCollapse()` instance per
+// scenario (it is not a singleton — see ADR 0001), so no explicit reset step
+// is needed for it, unlike `energy`.
 export class EnergyWorld extends World {
   energy = useEnergyLevel()
+  sections = useSectionCollapse()
+  // Tracks which section a preceding When step most recently acted on, so a
+  // later "the other sections should remain expanded" step can identify
+  // "the other two" without repeating the section name in the Gherkin.
+  lastToggledSectionKey: SectionKey | null = null
 }
 
 setWorldConstructor(EnergyWorld)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2704,9 +2704,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -4057,9 +4057,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4424,9 +4424,9 @@
       }
     },
     "node_modules/@vue/language-core/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4894,9 +4894,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4914,9 +4914,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4925,9 +4925,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -4945,11 +4945,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5078,9 +5078,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001800",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -5635,9 +5635,9 @@
       }
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5677,9 +5677,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.383",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.383.tgz",
-      "integrity": "sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==",
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6261,9 +6261,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -6335,9 +6335,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6738,9 +6738,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8006,9 +8006,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8425,9 +8425,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -8474,9 +8474,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8587,9 +8587,9 @@
       }
     },
     "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9735,9 +9735,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11140,9 +11140,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {
@@ -11935,9 +11935,9 @@
       }
     },
     "node_modules/workbox-build/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import EnergySelector from './components/EnergySelector.vue'
 import EncourageButton from './components/EncourageButton.vue'
 import ToughLoveButton from './components/ToughLoveButton.vue'
 import ToastNotification from './components/ToastNotification.vue'
+import NowNextLaterBoard from './components/NowNextLaterBoard.vue'
 </script>
 
 <template>
@@ -35,6 +36,7 @@ import ToastNotification from './components/ToastNotification.vue'
         <ToughLoveButton />
       </div>
     </header>
+    <NowNextLaterBoard />
     <ToastNotification />
   </main>
 </template>

--- a/src/components/CollapsibleSection.vue
+++ b/src/components/CollapsibleSection.vue
@@ -23,10 +23,10 @@ const contentId = computed(() => `section-${props.sectionKey}-content`)
         class="section-toggle"
         :aria-expanded="expanded"
         :aria-controls="contentId"
+        :aria-label="expanded ? `Collapse ${label}` : `Expand ${label}`"
         @click="$emit('toggle')"
       >
-        {{ expanded ? `Collapse ${label}` : `Expand ${label}` }}
-        <span class="chevron" aria-hidden="true">▾</span>
+        <span class="chevron" :class="{ 'chevron--expanded': expanded }" aria-hidden="true">▾</span>
       </button>
     </div>
     <div :id="contentId" class="section-content" :hidden="!expanded"></div>
@@ -60,6 +60,7 @@ const contentId = computed(() => `section-${props.sectionKey}-content`)
      that breakpoint — see the design's "Accessibility" section for the full explanation. */
   display: none; /* desktop-first: no control at all above 640px, Requirement 3 */
   align-items: center;
+  justify-content: center;
   gap: 0.4rem;
   font-size: 0.85rem;
   font-weight: 500;
@@ -69,6 +70,19 @@ const contentId = computed(() => `section-${props.sectionKey}-content`)
   background: #fff;
   color: #1a1a1a;
   cursor: pointer;
+}
+.chevron {
+  /* Amended 2026-09-06, issue #105: the chevron is now the button's only visible content, so its
+     rotation is the sole visual cue for expanded/collapsed state that visible text used to carry.
+     Glyph color inherits from .section-toggle's `color: #1a1a1a` (already contrast-audited,
+     Requirement 15); no new color introduced. */
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+.chevron--expanded {
+  /* ▾ (points down, "expand" affordance) rotates to point up when the section is expanded,
+     i.e. "click to collapse upward" */
+  transform: rotate(180deg);
 }
 .section-content {
   padding: 0 1.1rem 1rem;

--- a/src/components/CollapsibleSection.vue
+++ b/src/components/CollapsibleSection.vue
@@ -26,9 +26,7 @@ const contentId = computed(() => `section-${props.sectionKey}-content`)
         @click="$emit('toggle')"
       >
         {{ expanded ? `Collapse ${label}` : `Expand ${label}` }}
-        <span class="chevron" :class="{ 'chevron--collapsed': !expanded }" aria-hidden="true"
-          >▾</span
-        >
+        <span class="chevron" aria-hidden="true">▾</span>
       </button>
     </div>
     <div :id="contentId" class="section-content" :hidden="!expanded"></div>

--- a/src/components/CollapsibleSection.vue
+++ b/src/components/CollapsibleSection.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { SectionKey } from '../composables/useSectionCollapse'
+
+const props = defineProps<{
+  sectionKey: SectionKey
+  label: string
+  expanded: boolean
+}>()
+
+defineEmits<{ toggle: [] }>()
+
+const headingId = computed(() => `section-${props.sectionKey}-heading`)
+const contentId = computed(() => `section-${props.sectionKey}-content`)
+</script>
+
+<template>
+  <section class="now-next-later-section" :aria-labelledby="headingId">
+    <div class="section-header">
+      <h2 :id="headingId" class="section-heading">{{ label }}</h2>
+      <button
+        type="button"
+        class="section-toggle"
+        :aria-expanded="expanded"
+        :aria-controls="contentId"
+        @click="$emit('toggle')"
+      >
+        {{ expanded ? `Collapse ${label}` : `Expand ${label}` }}
+        <span class="chevron" :class="{ 'chevron--collapsed': !expanded }" aria-hidden="true"
+          >▾</span
+        >
+      </button>
+    </div>
+    <div :id="contentId" class="section-content" :hidden="!expanded"></div>
+  </section>
+</template>
+
+<style scoped>
+.now-next-later-section {
+  border: 1px solid #e2e2e2;
+  border-radius: 0.5rem;
+  background: #fff;
+}
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1.1rem;
+}
+.section-heading {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+.section-toggle {
+  /* LOAD-BEARING for Requirement 10 (aria-expanded correctness), not just Requirement 3's layout:
+     this rule removes the button from the accessibility tree above 640px, which is the only
+     reason a technically-stale aria-expanded value at that breakpoint is harmless (no AT user can
+     ever reach a control that isn't exposed). Do not replace this with a visual-only hiding
+     technique (e.g. opacity/visibility/clip) without also re-deriving aria-expanded correctly for
+     that breakpoint — see the design's "Accessibility" section for the full explanation. */
+  display: none; /* desktop-first: no control at all above 640px, Requirement 3 */
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.4rem 0.7rem;
+  border-radius: 0.4rem;
+  border: 1px solid #d6d6d6;
+  background: #fff;
+  color: #1a1a1a;
+  cursor: pointer;
+}
+.section-content {
+  padding: 0 1.1rem 1rem;
+}
+.section-content[hidden] {
+  display: block; /* neutralize native [hidden] default above 640px: always expanded, Requirement 3 */
+}
+@media (max-width: 640px) {
+  .section-toggle {
+    display: inline-flex;
+    min-height: 44px;
+    min-width: 44px; /* existing ~44px tap-target convention */
+  }
+  .section-content[hidden] {
+    display: none; /* respect real collapsed state at/below 640px, Requirements 4/14 */
+  }
+}
+</style>

--- a/src/components/NowNextLaterBoard.vue
+++ b/src/components/NowNextLaterBoard.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import CollapsibleSection from './CollapsibleSection.vue'
+import { useSectionCollapse, SECTION_DEFS } from '../composables/useSectionCollapse'
+
+const { expanded, toggle } = useSectionCollapse()
+</script>
+
+<template>
+  <div class="now-next-later-board">
+    <CollapsibleSection
+      v-for="section in SECTION_DEFS"
+      :key="section.key"
+      :section-key="section.key"
+      :label="section.label"
+      :expanded="expanded[section.key]"
+      @toggle="toggle(section.key)"
+    />
+  </div>
+</template>
+
+<style scoped>
+.now-next-later-board {
+  display: flex;
+  flex-direction: row; /* desktop-first: columns, Requirement 3 */
+  gap: 1rem;
+  margin-top: 6rem; /* clears the absolutely-positioned .brand header at >640px — implementer:
+                        verify visually against actual rendered header height, including the
+                        case where .header-actions wraps to a second line on narrower desktop
+                        widths (~641–900px); adjust this value if the header overlaps content */
+  padding: 0 1.5rem 1.5rem;
+}
+.now-next-later-board > * {
+  flex: 1 1 0;
+  min-width: 0;
+}
+@media (max-width: 640px) {
+  .now-next-later-board {
+    flex-direction: column; /* rows, Requirement 4 */
+    margin-top: 1rem; /* .brand is position: static at this breakpoint and already occupies
+                          flow space, so only a small gap is needed here */
+  }
+}
+</style>

--- a/src/composables/useSectionCollapse.ts
+++ b/src/composables/useSectionCollapse.ts
@@ -1,0 +1,28 @@
+import { reactive } from 'vue'
+
+export type SectionKey = 'now' | 'next' | 'later'
+
+export interface SectionDef {
+  key: SectionKey
+  label: string
+}
+
+export const SECTION_DEFS: SectionDef[] = [
+  { key: 'now', label: 'Now' },
+  { key: 'next', label: 'Next' },
+  { key: 'later', label: 'Later' },
+]
+
+export function useSectionCollapse() {
+  const expanded = reactive<Record<SectionKey, boolean>>({
+    now: true,
+    next: true,
+    later: true,
+  })
+
+  function toggle(key: SectionKey) {
+    expanded[key] = !expanded[key]
+  }
+
+  return { expanded, toggle }
+}

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -1,6 +1,6 @@
 import AxeBuilder from '@axe-core/playwright'
 import { test, expect } from './coverage-fixture'
-import { energyButton, encourageButton, toughLoveButton, toast } from './helpers'
+import { energyButton, encourageButton, toughLoveButton, toast, sectionToggle } from './helpers'
 
 // Scope to actual WCAG 2.1 A/AA success criteria, not axe-core's broader
 // "best-practice" rule set. Mirrors .claude/STANDARDS.md's WCAG conformance scope.
@@ -13,6 +13,9 @@ test.beforeEach(async ({ page }) => {
 })
 
 test('home page has no detectable accessibility violations', async ({ page }) => {
+  // Also covers the Now/Next/Later board's default desktop viewport, full-page,
+  // all-expanded state (Requirement 15) — no separate test needed since the board
+  // renders unconditionally as part of the home page.
   const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze()
   expect(results.violations).toEqual([])
 })
@@ -39,4 +42,15 @@ test('has no violations with the Tough love toast showing', async ({ page }) => 
 
   const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze()
   expect(results.violations).toEqual([])
+})
+
+test.describe('Now/Next/Later sections at mobile viewport (375x812)', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+
+  test('has no violations with a section collapsed', async ({ page }) => {
+    await sectionToggle(page, 'Now').click()
+
+    const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze()
+    expect(results.violations).toEqual([])
+  })
 })

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -15,3 +15,11 @@ export function encourageButton(page: Page) {
 export function toughLoveButton(page: Page) {
   return page.getByRole('button', { name: 'Tough love', exact: true })
 }
+
+export function sectionToggle(page: Page, label: string) {
+  return page.getByRole('button', { name: new RegExp(`^(Collapse|Expand) ${label}$`) })
+}
+
+export function sectionContent(page: Page, key: string) {
+  return page.locator(`#section-${key}-content`)
+}

--- a/tests/e2e/now-next-later.spec.ts
+++ b/tests/e2e/now-next-later.spec.ts
@@ -152,7 +152,7 @@ test.describe('cross-breakpoint persistence (Requirement 7)', () => {
     // and no toggle button is exposed to the accessibility tree.
     await expect(sectionContent(page, 'now')).toBeVisible()
     await expect(
-      page.getByRole('button', { name: /^(Collapse|Expand) (Now|Next|Later)$/ }),
+      page.getByRole('button', { name: /^(Collapse|Expand) (Now|Next|Later)$/ })
     ).toHaveCount(0)
 
     await page.setViewportSize({ width: 375, height: 812 })

--- a/tests/e2e/now-next-later.spec.ts
+++ b/tests/e2e/now-next-later.spec.ts
@@ -62,9 +62,13 @@ test.describe('mobile viewport (375x812)', () => {
     await expect(sectionToggle(page, 'Next')).toBeVisible()
     await expect(sectionToggle(page, 'Later')).toBeVisible()
 
-    await expect(sectionToggle(page, 'Now')).toContainText('Collapse Now')
-    await expect(sectionToggle(page, 'Next')).toContainText('Collapse Next')
-    await expect(sectionToggle(page, 'Later')).toContainText('Collapse Later')
+    await expect(sectionToggle(page, 'Now')).toHaveAttribute('aria-label', 'Collapse Now')
+    await expect(sectionToggle(page, 'Next')).toHaveAttribute('aria-label', 'Collapse Next')
+    await expect(sectionToggle(page, 'Later')).toHaveAttribute('aria-label', 'Collapse Later')
+
+    // Icon-only button: the visible rendered text is the chevron glyph only, not the old wording.
+    // aria-hidden only removes the chevron from the accessibility tree, not from innerText.
+    expect(await sectionToggle(page, 'Now').innerText()).toBe('▾')
   })
 
   test('gives the section toggle a 44px minimum tap target', async ({ page }) => {
@@ -90,12 +94,12 @@ test.describe('mobile viewport (375x812)', () => {
     const toggle = sectionToggle(page, 'Now')
 
     await expect(toggle).toHaveAttribute('aria-expanded', 'true')
-    await expect(toggle).toContainText('Collapse Now')
+    await expect(toggle).toHaveAttribute('aria-label', 'Collapse Now')
 
     await toggle.click()
 
     await expect(toggle).toHaveAttribute('aria-expanded', 'false')
-    await expect(toggle).toContainText('Expand Now')
+    await expect(toggle).toHaveAttribute('aria-label', 'Expand Now')
   })
 
   test('has aria-controls on the toggle referencing the content region id', async ({ page }) => {

--- a/tests/e2e/now-next-later.spec.ts
+++ b/tests/e2e/now-next-later.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from './coverage-fixture'
+import { sectionToggle, sectionContent } from './helpers'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('./')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+})
+
+test.describe('desktop viewport (>640px)', () => {
+  test('renders the three sections as columns, side by side', async ({ page }) => {
+    const nowBox = await page.getByRole('region', { name: 'Now', exact: true }).boundingBox()
+    const nextBox = await page.getByRole('region', { name: 'Next', exact: true }).boundingBox()
+    const laterBox = await page.getByRole('region', { name: 'Later', exact: true }).boundingBox()
+
+    expect(nowBox).not.toBeNull()
+    expect(nextBox).not.toBeNull()
+    expect(laterBox).not.toBeNull()
+
+    // Columns: roughly the same vertical position, strictly increasing horizontal position.
+    expect(Math.abs(nextBox!.y - nowBox!.y)).toBeLessThan(20)
+    expect(Math.abs(laterBox!.y - nowBox!.y)).toBeLessThan(20)
+    expect(nextBox!.x).toBeGreaterThan(nowBox!.x)
+    expect(laterBox!.x).toBeGreaterThan(nextBox!.x)
+  })
+
+  test('exposes no collapse/expand toggle button to the accessibility tree', async ({ page }) => {
+    const toggles = page.getByRole('button', { name: /^(Collapse|Expand) (Now|Next|Later)$/ })
+    await expect(toggles).toHaveCount(0)
+  })
+
+  test('renders all three section content regions as visible', async ({ page }) => {
+    await expect(sectionContent(page, 'now')).toBeVisible()
+    await expect(sectionContent(page, 'next')).toBeVisible()
+    await expect(sectionContent(page, 'later')).toBeVisible()
+  })
+})
+
+test.describe('mobile viewport (375x812)', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+
+  test('stacks the three sections as rows spanning close to the full width', async ({ page }) => {
+    const nowBox = await page.getByRole('region', { name: 'Now', exact: true }).boundingBox()
+    const nextBox = await page.getByRole('region', { name: 'Next', exact: true }).boundingBox()
+    const laterBox = await page.getByRole('region', { name: 'Later', exact: true }).boundingBox()
+
+    expect(nowBox).not.toBeNull()
+    expect(nextBox).not.toBeNull()
+    expect(laterBox).not.toBeNull()
+
+    expect(nextBox!.y).toBeGreaterThan(nowBox!.y)
+    expect(laterBox!.y).toBeGreaterThan(nextBox!.y)
+    for (const box of [nowBox, nextBox, laterBox]) {
+      expect(box!.width).toBeGreaterThan(300)
+    }
+  })
+
+  test('exposes a visible toggle per section with an accessible name including the label', async ({
+    page,
+  }) => {
+    await expect(sectionToggle(page, 'Now')).toBeVisible()
+    await expect(sectionToggle(page, 'Next')).toBeVisible()
+    await expect(sectionToggle(page, 'Later')).toBeVisible()
+
+    await expect(sectionToggle(page, 'Now')).toContainText('Collapse Now')
+    await expect(sectionToggle(page, 'Next')).toContainText('Collapse Next')
+    await expect(sectionToggle(page, 'Later')).toContainText('Collapse Later')
+  })
+
+  test('gives the section toggle a 44px minimum tap target', async ({ page }) => {
+    for (const label of ['Now', 'Next', 'Later']) {
+      const box = await sectionToggle(page, label).boundingBox()
+      expect(box).not.toBeNull()
+      expect(box!.height).toBeGreaterThanOrEqual(44)
+      expect(box!.width).toBeGreaterThanOrEqual(44)
+    }
+  })
+
+  test('collapsing one section does not affect the other two (independence)', async ({ page }) => {
+    await sectionToggle(page, 'Now').click()
+
+    await expect(sectionContent(page, 'now')).toBeHidden()
+    await expect(sectionContent(page, 'next')).toBeVisible()
+    await expect(sectionContent(page, 'later')).toBeVisible()
+  })
+
+  test('clicking a toggle flips its aria-expanded attribute and accessible name', async ({
+    page,
+  }) => {
+    const toggle = sectionToggle(page, 'Now')
+
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(toggle).toContainText('Collapse Now')
+
+    await toggle.click()
+
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(toggle).toContainText('Expand Now')
+  })
+
+  test('has aria-controls on the toggle referencing the content region id', async ({ page }) => {
+    const toggle = sectionToggle(page, 'Now')
+    await expect(toggle).toHaveAttribute('aria-controls', 'section-now-content')
+  })
+
+  test('is keyboard operable via Enter and Space', async ({ page }) => {
+    const toggle = sectionToggle(page, 'Now')
+    await toggle.focus()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+    await page.keyboard.press('Enter')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    await page.keyboard.press('Space')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  test('shows a visible focus indicator when a toggle is focused', async ({ page }) => {
+    const toggle = sectionToggle(page, 'Now')
+    await toggle.focus()
+
+    const style = await toggle.evaluate((el) => {
+      const cs = getComputedStyle(el)
+      return { outlineStyle: cs.outlineStyle, outlineWidth: cs.outlineWidth }
+    })
+
+    expect(style.outlineStyle).not.toBe('none')
+    expect(parseFloat(style.outlineWidth)).toBeGreaterThan(0)
+  })
+
+  test('reload resets collapsed sections back to fully expanded', async ({ page }) => {
+    await sectionToggle(page, 'Now').click()
+    await expect(sectionContent(page, 'now')).toBeHidden()
+
+    await page.reload()
+
+    await expect(sectionContent(page, 'now')).toBeVisible()
+    await expect(sectionToggle(page, 'Now')).toHaveAttribute('aria-expanded', 'true')
+  })
+})
+
+test.describe('cross-breakpoint persistence (Requirement 7)', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+
+  test('collapse state survives resizing across the 640px breakpoint', async ({ page }) => {
+    await sectionToggle(page, 'Now').click()
+    await expect(sectionContent(page, 'now')).toBeHidden()
+
+    await page.setViewportSize({ width: 1280, height: 800 })
+
+    // Above 640px, Requirement 3 forces content visible regardless of stored state,
+    // and no toggle button is exposed to the accessibility tree.
+    await expect(sectionContent(page, 'now')).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /^(Collapse|Expand) (Now|Next|Later)$/ }),
+    ).toHaveCount(0)
+
+    await page.setViewportSize({ width: 375, height: 812 })
+
+    // Resizing back down reveals the state was preserved in memory the whole time,
+    // not reset by the round-trip across the breakpoint.
+    await expect(sectionContent(page, 'now')).toBeHidden()
+    await expect(sectionContent(page, 'next')).toBeVisible()
+    await expect(sectionContent(page, 'later')).toBeVisible()
+  })
+})

--- a/tests/unit/now-next-later/components.test.ts
+++ b/tests/unit/now-next-later/components.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { reactive, ref } from 'vue'
+import { axe } from 'jest-axe'
+import CollapsibleSection from '../../../src/components/CollapsibleSection.vue'
+import NowNextLaterBoard from '../../../src/components/NowNextLaterBoard.vue'
+import App from '../../../src/App.vue'
+
+// toHaveNoViolations matcher is registered globally in vitest.setup.ts.
+// Mirrors .claude/STANDARDS.md's WCAG conformance scope.
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+
+// jsdom has no real rendering engine to evaluate color-contrast against;
+// that check is covered at the e2e layer (tests/e2e/a11y.spec.ts) instead.
+async function expectNoAxeViolations(root: Element) {
+  const results = await axe(root, {
+    runOnly: { type: 'tag', values: WCAG_TAGS },
+    rules: { 'color-contrast': { enabled: false } },
+  })
+  expect(results).toHaveNoViolations()
+}
+
+const sectionState = {
+  expanded: reactive({ now: true, next: true, later: true }),
+  toggle: vi.fn(),
+}
+
+vi.mock('../../../src/composables/useSectionCollapse', () => ({
+  useSectionCollapse: () => sectionState,
+  SECTION_DEFS: [
+    { key: 'now', label: 'Now' },
+    { key: 'next', label: 'Next' },
+    { key: 'later', label: 'Later' },
+  ],
+}))
+
+const energyState = {
+  selectedLevel: ref<'low' | 'medium' | 'high' | null>(null),
+  toastMessage: ref<string | null>(null),
+  toastId: ref(0),
+  selectLevel: vi.fn(),
+  dismissToast: vi.fn(),
+  encourageMe: vi.fn(),
+  toughLove: vi.fn(),
+}
+
+vi.mock('../../../src/composables/useEnergyLevel', () => ({
+  useEnergyLevel: () => energyState,
+}))
+
+let mountedWrappers: VueWrapper[] = []
+
+function mountTracked(component: Parameters<typeof mount>[0], props?: Record<string, unknown>) {
+  const wrapper = mount(component, { attachTo: document.body, props })
+  mountedWrappers.push(wrapper)
+  return wrapper
+}
+
+beforeEach(() => {
+  sectionState.expanded.now = true
+  sectionState.expanded.next = true
+  sectionState.expanded.later = true
+  sectionState.toggle.mockReset()
+
+  energyState.selectedLevel.value = null
+  energyState.toastMessage.value = null
+  energyState.toastId.value = 0
+  energyState.selectLevel.mockReset()
+  energyState.dismissToast.mockReset()
+  energyState.encourageMe.mockReset()
+  energyState.toughLove.mockReset()
+})
+
+afterEach(() => {
+  mountedWrappers.forEach((wrapper) => wrapper.unmount())
+  mountedWrappers = []
+})
+
+describe('NowNextLaterBoard', () => {
+  it('renders exactly three CollapsibleSection instances in Now/Next/Later order', () => {
+    const wrapper = mountTracked(NowNextLaterBoard)
+    const sections = wrapper.findAllComponents(CollapsibleSection)
+
+    expect(sections).toHaveLength(3)
+    expect(sections.map((section) => section.props('label'))).toEqual(['Now', 'Next', 'Later'])
+  })
+
+  it.each([
+    ['Now', 'now'],
+    ['Next', 'next'],
+    ['Later', 'later'],
+  ])('clicking the %s toggle button calls toggle with its key', async (_label, key) => {
+    const wrapper = mountTracked(NowNextLaterBoard)
+    const sections = wrapper.findAllComponents(CollapsibleSection)
+    const target = sections.find((section) => section.props('sectionKey') === key)!
+
+    await target.find('button').trigger('click')
+
+    expect(sectionState.toggle).toHaveBeenCalledWith(key)
+  })
+
+  it('has no accessibility violations in the default all-expanded state', async () => {
+    const wrapper = mountTracked(NowNextLaterBoard)
+    await expectNoAxeViolations(wrapper.element)
+  })
+
+  it('has no accessibility violations in a mixed collapsed/expanded state', async () => {
+    sectionState.expanded.now = false
+    const wrapper = mountTracked(NowNextLaterBoard)
+    await expectNoAxeViolations(wrapper.element)
+  })
+})
+
+describe('CollapsibleSection', () => {
+  const baseProps = { sectionKey: 'now', label: 'Now', expanded: true }
+
+  it('renders a section labelled by its heading', () => {
+    const wrapper = mountTracked(CollapsibleSection, baseProps)
+    const section = wrapper.find('section')
+    const heading = wrapper.find('h2')
+
+    expect(heading.text()).toBe('Now')
+    expect(section.attributes('aria-labelledby')).toBe(heading.attributes('id'))
+  })
+
+  it('shows "Collapse {label}" as the button text when expanded', () => {
+    const wrapper = mountTracked(CollapsibleSection, { ...baseProps, expanded: true })
+    expect(wrapper.find('button').text()).toContain('Collapse Now')
+  })
+
+  it('shows "Expand {label}" as the button text when collapsed', () => {
+    const wrapper = mountTracked(CollapsibleSection, { ...baseProps, expanded: false })
+    expect(wrapper.find('button').text()).toContain('Expand Now')
+  })
+
+  it('sets aria-expanded to match the expanded prop', () => {
+    const expandedWrapper = mountTracked(CollapsibleSection, { ...baseProps, expanded: true })
+    expect(expandedWrapper.find('button').attributes('aria-expanded')).toBe('true')
+
+    const collapsedWrapper = mountTracked(CollapsibleSection, { ...baseProps, expanded: false })
+    expect(collapsedWrapper.find('button').attributes('aria-expanded')).toBe('false')
+  })
+
+  it('sets aria-controls on the button to the content region id', () => {
+    const wrapper = mountTracked(CollapsibleSection, baseProps)
+    const button = wrapper.find('button')
+    const content = wrapper.find('.section-content')
+
+    expect(button.attributes('aria-controls')).toBe(content.attributes('id'))
+  })
+
+  it('hides the content region when collapsed and shows it when expanded', () => {
+    const expandedWrapper = mountTracked(CollapsibleSection, { ...baseProps, expanded: true })
+    expect(expandedWrapper.find('.section-content').attributes('hidden')).toBeUndefined()
+
+    const collapsedWrapper = mountTracked(CollapsibleSection, { ...baseProps, expanded: false })
+    expect(collapsedWrapper.find('.section-content').attributes('hidden')).toBeDefined()
+  })
+
+  it('emits toggle when the button is clicked', async () => {
+    const wrapper = mountTracked(CollapsibleSection, baseProps)
+
+    await wrapper.find('button').trigger('click')
+
+    expect(wrapper.emitted('toggle')).toHaveLength(1)
+  })
+
+  it('has no accessibility violations when expanded', async () => {
+    const wrapper = mountTracked(CollapsibleSection, { ...baseProps, expanded: true })
+    await expectNoAxeViolations(wrapper.element)
+  })
+
+  it('has no accessibility violations when collapsed', async () => {
+    const wrapper = mountTracked(CollapsibleSection, { ...baseProps, expanded: false })
+    await expectNoAxeViolations(wrapper.element)
+  })
+})
+
+describe('App', () => {
+  it('renders a NowNextLaterBoard after the header', () => {
+    const wrapper = mountTracked(App)
+    const board = wrapper.findComponent(NowNextLaterBoard)
+
+    expect(board.exists()).toBe(true)
+
+    const main = wrapper.find('main')
+    const children = Array.from(main.element.children)
+    const headerIndex = children.findIndex((el) => el.tagName.toLowerCase() === 'header')
+    const boardIndex = children.indexOf(board.element as Element)
+
+    expect(headerIndex).toBeGreaterThanOrEqual(0)
+    expect(boardIndex).toBeGreaterThan(headerIndex)
+  })
+
+  it('has no accessibility violations', async () => {
+    const wrapper = mountTracked(App)
+    await expectNoAxeViolations(wrapper.element)
+  })
+})

--- a/tests/unit/now-next-later/components.test.ts
+++ b/tests/unit/now-next-later/components.test.ts
@@ -123,14 +123,14 @@ describe('CollapsibleSection', () => {
     expect(section.attributes('aria-labelledby')).toBe(heading.attributes('id'))
   })
 
-  it('shows "Collapse {label}" as the button text when expanded', () => {
+  it('sets the button\'s aria-label to "Collapse {label}" when expanded', () => {
     const wrapper = mountTracked(CollapsibleSection, { ...baseProps, expanded: true })
-    expect(wrapper.find('button').text()).toContain('Collapse Now')
+    expect(wrapper.find('.section-toggle').attributes('aria-label')).toBe('Collapse Now')
   })
 
-  it('shows "Expand {label}" as the button text when collapsed', () => {
+  it('sets the button\'s aria-label to "Expand {label}" when collapsed', () => {
     const wrapper = mountTracked(CollapsibleSection, { ...baseProps, expanded: false })
-    expect(wrapper.find('button').text()).toContain('Expand Now')
+    expect(wrapper.find('.section-toggle').attributes('aria-label')).toBe('Expand Now')
   })
 
   it('sets aria-expanded to match the expanded prop', () => {

--- a/tests/unit/now-next-later/composable.test.ts
+++ b/tests/unit/now-next-later/composable.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { useSectionCollapse, SECTION_DEFS } from '../../../src/composables/useSectionCollapse'
+
+describe('useSectionCollapse', () => {
+  it('defaults every section to expanded', () => {
+    const { expanded } = useSectionCollapse()
+    expect(expanded).toEqual({ now: true, next: true, later: true })
+  })
+
+  it('toggling one section flips only that section', () => {
+    const { expanded, toggle } = useSectionCollapse()
+
+    toggle('now')
+
+    expect(expanded.now).toBe(false)
+    expect(expanded.next).toBe(true)
+    expect(expanded.later).toBe(true)
+  })
+
+  it('toggling the same section twice returns it to its original value', () => {
+    const { expanded, toggle } = useSectionCollapse()
+
+    toggle('next')
+    toggle('next')
+
+    expect(expanded.next).toBe(true)
+  })
+
+  it('produces independent state across separate calls (non-singleton)', () => {
+    const first = useSectionCollapse()
+    const second = useSectionCollapse()
+
+    first.toggle('later')
+
+    expect(first.expanded.later).toBe(false)
+    expect(second.expanded.later).toBe(true)
+  })
+
+  it('exposes SECTION_DEFS with exactly three entries in now/next/later order with fixed labels', () => {
+    expect(SECTION_DEFS).toHaveLength(3)
+    expect(SECTION_DEFS.map((section) => section.key)).toEqual(['now', 'next', 'later'])
+    expect(SECTION_DEFS.map((section) => section.label)).toEqual(['Now', 'Next', 'Later'])
+  })
+})


### PR DESCRIPTION
Closes #99

## Summary
- Adds three fixed sections — Now, Next, Later — as a layout scaffold below the existing header.
- Desktop (>640px): rendered as columns, always fully expanded, no collapse control.
- Mobile (<=640px): rendered as rows, each independently collapsible via an icon-only toggle button (accordion-per-section, not mutually exclusive).
- Collapse state is in-memory only via a new non-singleton composable (`useSectionCollapse.ts`, see ADR 0001), resets to fully expanded on reload, and survives resizing across the 640px breakpoint.
- Full WCAG 2.1 AA disclosure pattern: `aria-expanded`/`aria-controls`, accessible name via `aria-label`, native `hidden` removal from the a11y tree at mobile width, visible native focus indicator, keyboard operability, semantic `<section aria-labelledby>` grouping.

## Test plan
- [x] Unit (Vitest): 81/81 passing, including jest-axe scans
- [x] BDD (Cucumber): 22 scenarios / 87 steps passing
- [x] E2E (Playwright): 45/45 passing, including `@axe-core/playwright` scans and a base-path smoke check under the production `GITHUB_PAGES=true` build
- [x] Combined coverage: 100%
- [x] Manual test gate: passed (including icon-only toggle button follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)